### PR TITLE
Tab zoom

### DIFF
--- a/docs/features/ZoomFeature.specs.md
+++ b/docs/features/ZoomFeature.specs.md
@@ -35,8 +35,10 @@ Zoom is applied to the active tab's `WebContentsView` using Electron's `webConte
 
 This feature uses the following shortcuts:
 
-- **Ctrl-MouseWheel**: Change zoom level.
-- **Ctrl-Delete**: Reset zoom level.
+- **Ctrl+Plus (+)**: Zoom in.
+- **Ctrl+Minus (-)**: Zoom out.
+- **Ctrl+0**: Reset zoom level.
+- **Ctrl+MouseWheel**: Change zoom level (native Chromium behavior).
 
 ### Mouse interactions
 
@@ -53,9 +55,3 @@ This feature uses the following shortcuts:
 ### Events
 
 - `zoom:changed` — Zoom level changed. Payload: `{ tabId: string, zoomLevel: number }`.
-
-## Unresolved Issues
-
-- **Standard zoom shortcuts**: Most browsers also support Ctrl+Plus / Ctrl+Minus for zoom in/out. These should probably be supported in addition to Ctrl+MouseWheel.
-- **Ctrl-Delete for reset**: This is non-standard. Most browsers use Ctrl-0 to reset zoom. Consider using Ctrl-0 instead.
-- **Per-domain zoom memory**: Should zoom levels be remembered per-domain (like Chrome) so that returning to a site restores its previous zoom level?

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -5,7 +5,16 @@ import { defineConfig } from "electron-vite";
 
 export default defineConfig({
   main: {},
-  preload: {},
+  preload: {
+    build: {
+      rollupOptions: {
+        input: {
+          index: resolve(__dirname, "src/preload/index.ts"),
+          tab: resolve(__dirname, "src/preload/tab.ts"),
+        },
+      },
+    },
+  },
   renderer: {
     server: {
       port: 5199,

--- a/src/features/workspaces/workspaces.main.ts
+++ b/src/features/workspaces/workspaces.main.ts
@@ -5,7 +5,13 @@ import type { Platform } from "../../platform/types";
 import type { TabId, WindowId, WorkspaceId } from "../../shared/types";
 import { getTabsForWorkspace } from "../tabs/tabs.main";
 import type { TabsCommands, TabsEvents } from "../tabs/tabs.shared";
-import { TABS_ACTIVATE, TABS_ACTIVATED, TABS_NAVIGATE, TABS_UPDATED } from "../tabs/tabs.shared";
+import {
+  TABS_ACTIVATE,
+  TABS_ACTIVATED,
+  TABS_CLOSE,
+  TABS_NAVIGATE,
+  TABS_UPDATED,
+} from "../tabs/tabs.shared";
 import {
   type PersistedWorkspace,
   WORKSPACES_CREATE,
@@ -246,6 +252,31 @@ export function register(deps: Deps): void {
 
     await commands.send(TABS_NAVIGATE, { url: originalUrl, tabId });
   });
+
+  // ── Keyboard shortcuts ──────────────────────────────────────────
+  // Ctrl+W: Close current tab
+  platform.registerShortcut("CommandOrControl+W", () => {
+    const tabId = getActiveTabId();
+    if (tabId) commands.send(TABS_CLOSE, { tabId }).catch(console.error);
+  });
+
+  // Ctrl+1..9: Switch to workspace N
+  for (let n = 1; n <= 9; n++) {
+    platform.registerShortcut(`CommandOrControl+${n}`, () => {
+      const all = getAllWorkspaces();
+      const ws = all[n - 1];
+      if (ws) commands.send(WORKSPACES_SWITCH, { workspaceId: ws.id }).catch(console.error);
+    });
+  }
+
+  // Ctrl+Shift+1..9: Move current tab to workspace N
+  for (let n = 1; n <= 9; n++) {
+    platform.registerShortcut(`CommandOrControl+Shift+${n}`, () => {
+      const all = getAllWorkspaces();
+      const ws = all[n - 1];
+      if (ws) commands.send(WORKSPACES_MOVE_TAB, { targetWorkspaceId: ws.id }).catch(console.error);
+    });
+  }
 }
 
 export async function start(deps: Deps): Promise<void> {

--- a/src/features/zoom/zoom.main.ts
+++ b/src/features/zoom/zoom.main.ts
@@ -1,0 +1,106 @@
+import type { CommandBus } from "../../bus/command-bus";
+import type { EventBus } from "../../bus/event-bus";
+import type { Platform } from "../../platform/types";
+import type { TabId } from "../../shared/types";
+import {
+  TABS_CLOSED,
+  TABS_CREATED,
+  type TabsClosedEvent,
+  type TabsCreatedEvent,
+} from "../tabs/tabs.shared";
+import {
+  ZOOM_CHANGED,
+  ZOOM_DEFAULT,
+  ZOOM_IN,
+  ZOOM_MAX,
+  ZOOM_MIN,
+  ZOOM_OUT,
+  ZOOM_RESET,
+  ZOOM_STEP,
+  type ZoomCommands,
+  type ZoomEvents,
+} from "./zoom.shared";
+
+type AllEvents = ZoomEvents & { [K in typeof TABS_CREATED]: TabsCreatedEvent } & {
+  [K in typeof TABS_CLOSED]: TabsClosedEvent;
+};
+
+interface Deps {
+  commands: CommandBus<ZoomCommands>;
+  events: EventBus<AllEvents>;
+  platform: Platform;
+  getActiveTabId: () => TabId | undefined;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function register({ commands, events, platform, getActiveTabId }: Deps): void {
+  const tabCleanups = new Map<TabId, () => void>();
+
+  // ── Command handlers ───────────────────────────────────────────
+
+  commands.handle(ZOOM_IN, async () => {
+    const tabId = getActiveTabId();
+    if (!tabId) return;
+    const current = platform.getTabZoomLevel(tabId);
+    const next = clamp(current + ZOOM_STEP, ZOOM_MIN, ZOOM_MAX);
+    if (next === current) return;
+    platform.setTabZoomLevel(tabId, next);
+    events.emit(ZOOM_CHANGED, { tabId, zoomLevel: next });
+  });
+
+  commands.handle(ZOOM_OUT, async () => {
+    const tabId = getActiveTabId();
+    if (!tabId) return;
+    const current = platform.getTabZoomLevel(tabId);
+    const next = clamp(current - ZOOM_STEP, ZOOM_MIN, ZOOM_MAX);
+    if (next === current) return;
+    platform.setTabZoomLevel(tabId, next);
+    events.emit(ZOOM_CHANGED, { tabId, zoomLevel: next });
+  });
+
+  commands.handle(ZOOM_RESET, async () => {
+    const tabId = getActiveTabId();
+    if (!tabId) return;
+    const current = platform.getTabZoomLevel(tabId);
+    if (current === ZOOM_DEFAULT) return;
+    platform.setTabZoomLevel(tabId, ZOOM_DEFAULT);
+    events.emit(ZOOM_CHANGED, { tabId, zoomLevel: ZOOM_DEFAULT });
+  });
+
+  // ── Keyboard shortcuts ─────────────────────────────────────────
+
+  const zoomIn = () => commands.send(ZOOM_IN, undefined).catch(console.error);
+  const zoomOut = () => commands.send(ZOOM_OUT, undefined).catch(console.error);
+  const zoomReset = () => commands.send(ZOOM_RESET, undefined).catch(console.error);
+
+  // "=" for US layouts, "Plus" for layouts where + is the primary key
+  platform.registerShortcut("CommandOrControl+=", zoomIn);
+  platform.registerShortcut("CommandOrControl+Plus", zoomIn);
+  platform.registerShortcut("CommandOrControl+-", zoomOut);
+  platform.registerShortcut("CommandOrControl+0", zoomReset);
+
+  // ── Ctrl+MouseWheel zoom ─────────────────────────────────────────
+  // The tab preload applies zoom directly via webFrame and notifies
+  // the main process. This handler reads the already-applied level,
+  // clamps if needed, and emits the bus event for UI updates.
+
+  events.on(TABS_CREATED, ({ tab }) => {
+    const cleanup = platform.onTabEvent(tab.id, "zoom-changed", () => {
+      const level = platform.getTabZoomLevel(tab.id);
+      const clamped = clamp(level, ZOOM_MIN, ZOOM_MAX);
+      if (clamped !== level) {
+        platform.setTabZoomLevel(tab.id, clamped);
+      }
+      events.emit(ZOOM_CHANGED, { tabId: tab.id, zoomLevel: clamped });
+    });
+    tabCleanups.set(tab.id, cleanup);
+  });
+
+  events.on(TABS_CLOSED, ({ tabId }) => {
+    tabCleanups.get(tabId)?.();
+    tabCleanups.delete(tabId);
+  });
+}

--- a/src/features/zoom/zoom.shared.ts
+++ b/src/features/zoom/zoom.shared.ts
@@ -1,0 +1,33 @@
+import type { TabId } from "../../shared/types";
+
+// ── Command names ────────────────────────────────────────────────
+export const ZOOM_IN = "zoom:in" as const;
+export const ZOOM_OUT = "zoom:out" as const;
+export const ZOOM_RESET = "zoom:reset" as const;
+
+// ── Event names ──────────────────────────────────────────────────
+export const ZOOM_CHANGED = "zoom:changed" as const;
+
+// ── Constants ────────────────────────────────────────────────────
+export const ZOOM_MIN = -3;
+export const ZOOM_MAX = 3;
+export const ZOOM_STEP = 1;
+export const ZOOM_DEFAULT = 0;
+
+// ── Payload types ────────────────────────────────────────────────
+export interface ZoomChangedEvent {
+  tabId: TabId;
+  zoomLevel: number;
+}
+
+// ── Command registry ─────────────────────────────────────────────
+export type ZoomCommands = {
+  [ZOOM_IN]: { payload: undefined; response: undefined };
+  [ZOOM_OUT]: { payload: undefined; response: undefined };
+  [ZOOM_RESET]: { payload: undefined; response: undefined };
+};
+
+// ── Event registry ───────────────────────────────────────────────
+export type ZoomEvents = {
+  [ZOOM_CHANGED]: ZoomChangedEvent;
+};

--- a/src/features/zoom/zoom.test.ts
+++ b/src/features/zoom/zoom.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it, vi } from "vitest";
+import { CommandBus } from "../../bus/command-bus";
+import { EventBus } from "../../bus/event-bus";
+import type { TabId } from "../../shared/types";
+import { createMockPlatform, makeTab } from "../../test-utils";
+import {
+  TABS_CLOSED,
+  TABS_CREATED,
+  type TabsClosedEvent,
+  type TabsCreatedEvent,
+} from "../tabs/tabs.shared";
+import { register } from "./zoom.main";
+import {
+  ZOOM_CHANGED,
+  ZOOM_DEFAULT,
+  ZOOM_IN,
+  ZOOM_MAX,
+  ZOOM_MIN,
+  ZOOM_OUT,
+  ZOOM_RESET,
+  type ZoomCommands,
+  type ZoomEvents,
+} from "./zoom.shared";
+
+const TAB_ID = "tab-1" as TabId;
+
+type AllEvents = ZoomEvents & { [K in typeof TABS_CREATED]: TabsCreatedEvent } & {
+  [K in typeof TABS_CLOSED]: TabsClosedEvent;
+};
+
+function setup(opts: { initialZoom?: number } = {}) {
+  const commands = new CommandBus<ZoomCommands>();
+  const events = new EventBus<AllEvents>();
+  let currentZoom = opts.initialZoom ?? 0;
+  const platform = createMockPlatform({
+    getTabZoomLevel: vi.fn(() => currentZoom),
+    setTabZoomLevel: vi.fn((_tabId: TabId, level: number) => {
+      currentZoom = level;
+    }),
+  });
+
+  register({
+    commands,
+    events,
+    platform,
+    getActiveTabId: () => TAB_ID as TabId | undefined,
+  });
+
+  return { commands, events, platform, getZoom: () => currentZoom };
+}
+
+describe("zoom:in", () => {
+  it("increases zoom by step and emits changed", async () => {
+    const { commands, events, platform } = setup();
+    const changed = vi.fn();
+    events.on(ZOOM_CHANGED, changed);
+
+    await commands.send(ZOOM_IN, undefined);
+
+    expect(platform.setTabZoomLevel).toHaveBeenCalledWith(TAB_ID, 1);
+    expect(changed).toHaveBeenCalledWith({ tabId: TAB_ID, zoomLevel: 1 });
+  });
+
+  it("clamps at max zoom", async () => {
+    const { commands, events, platform } = setup({ initialZoom: ZOOM_MAX });
+    const changed = vi.fn();
+    events.on(ZOOM_CHANGED, changed);
+
+    await commands.send(ZOOM_IN, undefined);
+
+    expect(platform.setTabZoomLevel).not.toHaveBeenCalled();
+    expect(changed).not.toHaveBeenCalled();
+  });
+
+  it("does nothing without active tab", async () => {
+    const commands = new CommandBus<ZoomCommands>();
+    const events = new EventBus<AllEvents>();
+    const platform = createMockPlatform();
+    register({
+      commands,
+      events,
+      platform,
+      getActiveTabId: () => undefined,
+    });
+
+    const changed = vi.fn();
+    events.on(ZOOM_CHANGED, changed);
+
+    await commands.send(ZOOM_IN, undefined);
+
+    expect(platform.setTabZoomLevel).not.toHaveBeenCalled();
+    expect(changed).not.toHaveBeenCalled();
+  });
+});
+
+describe("zoom:out", () => {
+  it("decreases zoom by step and emits changed", async () => {
+    const { commands, events, platform } = setup();
+    const changed = vi.fn();
+    events.on(ZOOM_CHANGED, changed);
+
+    await commands.send(ZOOM_OUT, undefined);
+
+    expect(platform.setTabZoomLevel).toHaveBeenCalledWith(TAB_ID, -1);
+    expect(changed).toHaveBeenCalledWith({ tabId: TAB_ID, zoomLevel: -1 });
+  });
+
+  it("clamps at min zoom", async () => {
+    const { commands, events, platform } = setup({ initialZoom: ZOOM_MIN });
+    const changed = vi.fn();
+    events.on(ZOOM_CHANGED, changed);
+
+    await commands.send(ZOOM_OUT, undefined);
+
+    expect(platform.setTabZoomLevel).not.toHaveBeenCalled();
+    expect(changed).not.toHaveBeenCalled();
+  });
+});
+
+describe("zoom:reset", () => {
+  it("resets zoom to default and emits changed", async () => {
+    const { commands, events, platform } = setup({ initialZoom: 2 });
+    const changed = vi.fn();
+    events.on(ZOOM_CHANGED, changed);
+
+    await commands.send(ZOOM_RESET, undefined);
+
+    expect(platform.setTabZoomLevel).toHaveBeenCalledWith(TAB_ID, ZOOM_DEFAULT);
+    expect(changed).toHaveBeenCalledWith({ tabId: TAB_ID, zoomLevel: ZOOM_DEFAULT });
+  });
+
+  it("does nothing when already at default", async () => {
+    const { commands, events, platform } = setup({ initialZoom: ZOOM_DEFAULT });
+    const changed = vi.fn();
+    events.on(ZOOM_CHANGED, changed);
+
+    await commands.send(ZOOM_RESET, undefined);
+
+    expect(platform.setTabZoomLevel).not.toHaveBeenCalled();
+    expect(changed).not.toHaveBeenCalled();
+  });
+});
+
+describe("keyboard shortcuts", () => {
+  it("registers Ctrl+= and Ctrl+Plus for zoom in", () => {
+    const { platform } = setup();
+    expect(platform.registerShortcut).toHaveBeenCalledWith(
+      "CommandOrControl+=",
+      expect.any(Function),
+    );
+    expect(platform.registerShortcut).toHaveBeenCalledWith(
+      "CommandOrControl+Plus",
+      expect.any(Function),
+    );
+  });
+
+  it("registers Ctrl+- for zoom out", () => {
+    const { platform } = setup();
+    expect(platform.registerShortcut).toHaveBeenCalledWith(
+      "CommandOrControl+-",
+      expect.any(Function),
+    );
+  });
+
+  it("registers Ctrl+0 for zoom reset", () => {
+    const { platform } = setup();
+    expect(platform.registerShortcut).toHaveBeenCalledWith(
+      "CommandOrControl+0",
+      expect.any(Function),
+    );
+  });
+});
+
+describe("Ctrl+MouseWheel (zoom-changed)", () => {
+  it("subscribes to zoom-changed on new tabs", () => {
+    const { events, platform } = setup();
+    const tab = makeTab({ id: "tab-new" as TabId });
+
+    events.emit(TABS_CREATED, { tab });
+
+    expect(platform.onTabEvent).toHaveBeenCalledWith(
+      "tab-new",
+      "zoom-changed",
+      expect.any(Function),
+    );
+  });
+
+  it("reads applied level and emits changed", () => {
+    const { events, platform } = setup();
+    const tab = makeTab({ id: "tab-new" as TabId });
+    let onZoomChanged: (() => void) | undefined;
+    vi.mocked(platform.onTabEvent).mockImplementation((_tabId, _event, cb) => {
+      onZoomChanged = cb as () => void;
+      return () => {};
+    });
+
+    events.emit(TABS_CREATED, { tab });
+    // Preload already applied zoom to level 2
+    vi.mocked(platform.getTabZoomLevel).mockReturnValue(2);
+    const changed = vi.fn();
+    events.on(ZOOM_CHANGED, changed);
+
+    onZoomChanged?.();
+
+    expect(changed).toHaveBeenCalledWith({ tabId: "tab-new", zoomLevel: 2 });
+  });
+
+  it("clamps level that exceeds max", () => {
+    const { events, platform } = setup();
+    const tab = makeTab({ id: "tab-new" as TabId });
+    let onZoomChanged: (() => void) | undefined;
+    vi.mocked(platform.onTabEvent).mockImplementation((_tabId, _event, cb) => {
+      onZoomChanged = cb as () => void;
+      return () => {};
+    });
+
+    events.emit(TABS_CREATED, { tab });
+    vi.mocked(platform.getTabZoomLevel).mockReturnValue(5);
+
+    onZoomChanged?.();
+
+    expect(platform.setTabZoomLevel).toHaveBeenCalledWith("tab-new", ZOOM_MAX);
+  });
+
+  it("cleans up listener on tab close", () => {
+    const { events, platform } = setup();
+    const tab = makeTab({ id: "tab-new" as TabId });
+    const cleanup = vi.fn();
+    vi.mocked(platform.onTabEvent).mockReturnValue(cleanup);
+
+    events.emit(TABS_CREATED, { tab });
+    events.emit(TABS_CLOSED, { tabId: "tab-new" as TabId, activatedTabId: null });
+
+    expect(cleanup).toHaveBeenCalled();
+  });
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -183,6 +183,17 @@ app.whenReady().then(async () => {
     platform.initContextMenuOverlay(activeWindowId);
   }
 
+  // Activate keyboard shortcuts immediately (window is focused on creation)
+  // and toggle on focus/blur so they don't intercept keys from other apps.
+  platform.activateShortcuts();
+  app.on("browser-window-focus", () => platform.activateShortcuts());
+  app.on("browser-window-blur", () => {
+    // Small delay: focus may transfer between app windows (e.g. context menu)
+    setTimeout(() => {
+      if (!BrowserWindow.getFocusedWindow()) platform.deactivateShortcuts();
+    }, 100);
+  });
+
   // Phase 2: wait for renderer subscriptions, then emit initial state
   ipcMain.once("renderer:ready", async () => {
     await startWorkspaces(deps);
@@ -202,6 +213,7 @@ app.whenReady().then(async () => {
 });
 
 app.on("before-quit", () => {
+  platform.deactivateShortcuts();
   dataStore.destroy().catch(console.error);
 });
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -53,7 +53,6 @@ import {
   register as registerWorkspaces,
   start as startWorkspaces,
 } from "../features/workspaces/workspaces.main";
-import { getAllWorkspaces } from "../features/workspaces/workspaces.main";
 import type {
   WorkspacesCommands,
   WorkspacesEvents,
@@ -174,32 +173,6 @@ app.whenReady().then(async () => {
   registerContextMenu(deps);
   registerFolders(deps);
   registerZoom(deps);
-
-  // ── Global keyboard shortcuts ──────────────────────────────────
-  // Ctrl+W: Close current tab
-  platform.registerShortcut("CommandOrControl+W", () => {
-    const tabId = deps.getActiveTabId();
-    if (tabId) commands.send("tabs:close", { tabId }).catch(console.error);
-  });
-
-  // Ctrl+1..9: Switch to workspace N
-  for (let n = 1; n <= 9; n++) {
-    platform.registerShortcut(`CommandOrControl+${n}`, () => {
-      const all = getAllWorkspaces();
-      const ws = all[n - 1];
-      if (ws) commands.send("workspaces:switch", { workspaceId: ws.id }).catch(console.error);
-    });
-  }
-
-  // Ctrl+Shift+1..9: Move current tab to workspace N
-  for (let n = 1; n <= 9; n++) {
-    platform.registerShortcut(`CommandOrControl+Shift+${n}`, () => {
-      const all = getAllWorkspaces();
-      const ws = all[n - 1];
-      if (ws)
-        commands.send("workspaces:move-tab", { targetWorkspaceId: ws.id }).catch(console.error);
-    });
-  }
 
   // Bridge bus to IPC (once, before any window creation)
   bridgeBusToIpc(commands, events, () => BrowserWindow.getAllWindows());

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -58,6 +58,8 @@ import type {
   WorkspacesCommands,
   WorkspacesEvents,
 } from "../features/workspaces/workspaces.shared";
+import { register as registerZoom } from "../features/zoom/zoom.main";
+import type { ZoomCommands, ZoomEvents } from "../features/zoom/zoom.shared";
 import { ElectronPlatform } from "../platform/electron";
 import type { TabId, WindowId, WorkspaceId } from "../shared/types";
 
@@ -78,6 +80,7 @@ type AllCommands = MergeRegistries<
     TooltipCommands,
     ContextMenuCommands,
     FoldersCommands,
+    ZoomCommands,
   ]
 >;
 
@@ -92,6 +95,7 @@ type AllEvents = MergeRegistries<
     TooltipEvents,
     ContextMenuEvents,
     FoldersEvents,
+    ZoomEvents,
   ]
 >;
 
@@ -169,6 +173,7 @@ app.whenReady().then(async () => {
   registerTooltip(deps);
   registerContextMenu(deps);
   registerFolders(deps);
+  registerZoom(deps);
 
   // ── Global keyboard shortcuts ──────────────────────────────────
   // Ctrl+W: Close current tab

--- a/src/platform/electron.ts
+++ b/src/platform/electron.ts
@@ -1,55 +1,15 @@
 import path from "node:path";
-import { BrowserWindow, WebContentsView, clipboard, ipcMain, shell } from "electron";
+import {
+  BrowserWindow,
+  WebContentsView,
+  clipboard,
+  globalShortcut,
+  ipcMain,
+  shell,
+} from "electron";
 import type { TabId, WindowId } from "../shared/types";
 import type { Bounds } from "../shared/types";
 import type { Platform } from "./types";
-
-interface ParsedAccelerator {
-  ctrl: boolean;
-  shift: boolean;
-  alt: boolean;
-  meta: boolean;
-  key: string;
-}
-
-function parseAccelerator(accelerator: string): ParsedAccelerator {
-  const parts = accelerator.toLowerCase().split("+");
-  const result: ParsedAccelerator = { ctrl: false, shift: false, alt: false, meta: false, key: "" };
-  for (const part of parts) {
-    switch (part) {
-      case "commandorcontrol":
-      case "cmdorctrl":
-        if (process.platform === "darwin") {
-          result.meta = true;
-        } else {
-          result.ctrl = true;
-        }
-        break;
-      case "control":
-      case "ctrl":
-        result.ctrl = true;
-        break;
-      case "shift":
-        result.shift = true;
-        break;
-      case "alt":
-        result.alt = true;
-        break;
-      case "meta":
-      case "command":
-      case "cmd":
-      case "super":
-        result.meta = true;
-        break;
-      case "plus":
-        result.key = "+";
-        break;
-      default:
-        result.key = part;
-    }
-  }
-  return result;
-}
 
 const ALLOWED_SCHEMES = new Set(["http:", "https:", "about:", "data:"]);
 const ALLOWED_EXTERNAL_SCHEMES = new Set(["http:", "https:", "mailto:"]);
@@ -70,18 +30,6 @@ function isAllowedExternalUrl(url: string): boolean {
   } catch {
     return false;
   }
-}
-
-function matchesInput(parsed: ParsedAccelerator, input: Electron.Input): boolean {
-  if (input.type !== "keyDown") return false;
-  const key = input.key.toLowerCase();
-  return (
-    key === parsed.key &&
-    input.control === parsed.ctrl &&
-    input.shift === parsed.shift &&
-    input.alt === parsed.alt &&
-    input.meta === parsed.meta
-  );
 }
 
 // Minimal HTML for the tooltip popup — transparent bg, matching app styling
@@ -155,7 +103,7 @@ function awaitSelection(){
 </script></body></html>`;
 
 export class ElectronPlatform implements Platform {
-  private shortcuts = new Map<string, { parsed: ParsedAccelerator; callback: () => void }>();
+  private shortcuts = new Map<string, () => void>();
   private views = new Map<TabId, WebContentsView>();
   private tooltipWin: BrowserWindow | null = null;
   private ctxWin: BrowserWindow | null = null;
@@ -372,30 +320,42 @@ export class ElectronPlatform implements Platform {
     if (win) win.webContents.focus();
   }
 
-  // ── Keyboard shortcuts ──────────────────────────────────────────
+  // ── Keyboard shortcuts (via globalShortcut, toggled on focus/blur) ──
+
+  private shortcutsActive = false;
+
+  /** Register all stored shortcuts as OS-level global shortcuts. */
+  activateShortcuts(): void {
+    if (this.shortcutsActive) return;
+    for (const [accelerator, callback] of this.shortcuts) {
+      globalShortcut.register(accelerator, callback);
+    }
+    this.shortcutsActive = true;
+  }
+
+  /** Unregister all OS-level global shortcuts. */
+  deactivateShortcuts(): void {
+    if (!this.shortcutsActive) return;
+    globalShortcut.unregisterAll();
+    this.shortcutsActive = false;
+  }
 
   registerShortcut(accelerator: string, callback: () => void): void {
-    this.shortcuts.set(accelerator, {
-      parsed: parseAccelerator(accelerator),
-      callback,
-    });
+    this.shortcuts.set(accelerator, callback);
+    if (this.shortcutsActive) {
+      globalShortcut.register(accelerator, callback);
+    }
   }
 
   unregisterShortcut(accelerator: string): void {
     this.shortcuts.delete(accelerator);
+    if (this.shortcutsActive) {
+      globalShortcut.unregister(accelerator);
+    }
   }
 
-  hookWebContents(webContents: unknown): void {
-    const wc = webContents as Electron.WebContents;
-    wc.on("before-input-event", (event, input) => {
-      for (const { parsed, callback } of this.shortcuts.values()) {
-        if (matchesInput(parsed, input)) {
-          event.preventDefault();
-          callback();
-          return;
-        }
-      }
-    });
+  hookWebContents(_webContents: unknown): void {
+    // No-op: shortcuts handled via globalShortcut
   }
 
   // ── Tooltip overlay ────────────────────────────────────────────

--- a/src/platform/electron.ts
+++ b/src/platform/electron.ts
@@ -1,4 +1,5 @@
-import { BrowserWindow, WebContentsView, clipboard, shell } from "electron";
+import path from "node:path";
+import { BrowserWindow, WebContentsView, clipboard, ipcMain, shell } from "electron";
 import type { TabId, WindowId } from "../shared/types";
 import type { Bounds } from "../shared/types";
 import type { Platform } from "./types";
@@ -39,6 +40,9 @@ function parseAccelerator(accelerator: string): ParsedAccelerator {
       case "cmd":
       case "super":
         result.meta = true;
+        break;
+      case "plus":
+        result.key = "+";
         break;
       default:
         result.key = part;
@@ -214,6 +218,7 @@ export class ElectronPlatform implements Platform {
         contextIsolation: true,
         nodeIntegration: false,
         webSecurity: true,
+        preload: path.join(__dirname, "../preload/tab.js"),
       },
     });
 
@@ -244,6 +249,19 @@ export class ElectronPlatform implements Platform {
     });
 
     this.hookWebContents(view.webContents);
+
+    // The tab preload applies Ctrl+wheel zoom via webFrame and sends
+    // the resulting level here. We re-emit as a synthetic zoom-changed
+    // event so the zoom feature can read the new level and update state.
+    const onZoomApplied = (event: Electron.IpcMainEvent): void => {
+      if (event.sender === view.webContents) {
+        view.webContents.emit("zoom-changed");
+      }
+    };
+    ipcMain.on("tab:zoom-applied", onZoomApplied);
+    view.webContents.once("destroyed", () => {
+      ipcMain.removeListener("tab:zoom-applied", onZoomApplied);
+    });
 
     if (!isAllowedUrl(url)) throw new Error(`Blocked URL scheme: ${url}`);
     view.webContents.loadURL(url);
@@ -335,6 +353,16 @@ export class ElectronPlatform implements Platform {
 
   canGoForward(tabId: TabId): boolean {
     return this.views.get(tabId)?.webContents.canGoForward() ?? false;
+  }
+
+  // ── Zoom ──────────────────────────────────────────────────────
+
+  setTabZoomLevel(tabId: TabId, level: number): void {
+    this.views.get(tabId)?.webContents.setZoomLevel(level);
+  }
+
+  getTabZoomLevel(tabId: TabId): number {
+    return this.views.get(tabId)?.webContents.getZoomLevel() ?? 0;
   }
 
   // ── Focus ──────────────────────────────────────────────────────

--- a/src/platform/electron.ts
+++ b/src/platform/electron.ts
@@ -110,6 +110,7 @@ export class ElectronPlatform implements Platform {
   private ctxResolve: ((index: number) => void) | null = null;
   private ctxParentListenersSet = false;
   private permissionHandlerSet = false;
+  private zoomIpcHooked = false;
 
   constructor(private getActiveWindowId: () => WindowId | undefined) {}
 
@@ -201,15 +202,14 @@ export class ElectronPlatform implements Platform {
     // The tab preload applies Ctrl+wheel zoom via webFrame and sends
     // the resulting level here. We re-emit as a synthetic zoom-changed
     // event so the zoom feature can read the new level and update state.
-    const onZoomApplied = (event: Electron.IpcMainEvent): void => {
-      if (event.sender === view.webContents) {
-        view.webContents.emit("zoom-changed");
-      }
-    };
-    ipcMain.on("tab:zoom-applied", onZoomApplied);
-    view.webContents.once("destroyed", () => {
-      ipcMain.removeListener("tab:zoom-applied", onZoomApplied);
-    });
+    if (!this.zoomIpcHooked) {
+      ipcMain.on("tab:zoom-applied", (event: Electron.IpcMainEvent) => {
+        if (Array.from(this.views.values()).some((v) => v.webContents === event.sender)) {
+          event.sender.emit("zoom-changed");
+        }
+      });
+      this.zoomIpcHooked = true;
+    }
 
     if (!isAllowedUrl(url)) throw new Error(`Blocked URL scheme: ${url}`);
     view.webContents.loadURL(url);
@@ -336,7 +336,9 @@ export class ElectronPlatform implements Platform {
   /** Unregister all OS-level global shortcuts. */
   deactivateShortcuts(): void {
     if (!this.shortcutsActive) return;
-    globalShortcut.unregisterAll();
+    for (const accelerator of this.shortcuts.keys()) {
+      globalShortcut.unregister(accelerator);
+    }
     this.shortcutsActive = false;
   }
 

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -30,6 +30,10 @@ export interface Platform {
   canGoBack(tabId: TabId): boolean;
   canGoForward(tabId: TabId): boolean;
 
+  // Zoom
+  setTabZoomLevel(tabId: TabId, level: number): void;
+  getTabZoomLevel(tabId: TabId): number;
+
   // Keyboard shortcuts
   registerShortcut(accelerator: string, callback: () => void): void;
   unregisterShortcut(accelerator: string): void;

--- a/src/preload/tab.ts
+++ b/src/preload/tab.ts
@@ -1,0 +1,28 @@
+/// <reference lib="dom" />
+import { ipcRenderer, webFrame } from "electron";
+
+const ZOOM_MIN = -3;
+const ZOOM_MAX = 3;
+const ZOOM_STEP = 1;
+
+// Capture Ctrl+wheel for zoom — the 'zoom-changed' webContents event
+// doesn't fire reliably in WebContentsView, so we handle zoom directly
+// via webFrame and notify the main process via IPC.
+document.addEventListener(
+  "wheel",
+  (e: WheelEvent) => {
+    if (e.ctrlKey && e.deltaY !== 0) {
+      e.preventDefault();
+      const current = webFrame.getZoomLevel();
+      const next = Math.min(
+        ZOOM_MAX,
+        Math.max(ZOOM_MIN, current + (e.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP)),
+      );
+      if (next !== current) {
+        webFrame.setZoomLevel(next);
+        ipcRenderer.send("tab:zoom-applied", next);
+      }
+    }
+  },
+  { passive: false, capture: true },
+);

--- a/src/preload/tab.ts
+++ b/src/preload/tab.ts
@@ -1,9 +1,6 @@
 /// <reference lib="dom" />
 import { ipcRenderer, webFrame } from "electron";
-
-const ZOOM_MIN = -3;
-const ZOOM_MAX = 3;
-const ZOOM_STEP = 1;
+import { ZOOM_MAX, ZOOM_MIN, ZOOM_STEP } from "../features/zoom/zoom.shared";
 
 // Capture Ctrl+wheel for zoom — the 'zoom-changed' webContents event
 // doesn't fire reliably in WebContentsView, so we handle zoom directly

--- a/src/test-utils/mock-platform.ts
+++ b/src/test-utils/mock-platform.ts
@@ -24,6 +24,8 @@ export function createMockPlatform(overrides: Partial<Platform> = {}): Platform 
     reload: vi.fn(),
     canGoBack: vi.fn(() => false),
     canGoForward: vi.fn(() => false),
+    setTabZoomLevel: vi.fn(),
+    getTabZoomLevel: vi.fn(() => 0),
     registerShortcut: vi.fn(),
     unregisterShortcut: vi.fn(),
     hookWebContents: vi.fn(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added zoom controls: Ctrl+Plus (in), Ctrl+Minus (out), Ctrl+0 (reset)
  * Added Ctrl+MouseWheel zoom support for tabs
  * Added Ctrl+W to close the active tab
  * Added workspace navigation shortcuts: Ctrl+1-9 to switch workspaces, Ctrl+Shift+1-9 to move tabs

* **Documentation**
  * Updated keyboard shortcuts reference with new zoom and workspace shortcuts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->