### PR TITLE
Worktree app state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,3 +41,7 @@ Always verify your work compiles and passes checks. Run `bun run verify` for a f
 
 Always browse the application to verify changes affecting the UI.
 Do not assume that CSS changes are correct without verifying.
+
+# Git
+
+For GitHub auth, export GH_TOKEN from .env.local. If not set, ask the user to do so.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,3 @@ Always verify your work compiles and passes checks. Run `bun run verify` for a f
 
 Always browse the application to verify changes affecting the UI.
 Do not assume that CSS changes are correct without verifying.
-
-# Git
-
-For GitHub auth, export GH_TOKEN from .env.local. If not set, ask the user to do so.

--- a/docs/features/AppStateFeature.specs.md
+++ b/docs/features/AppStateFeature.specs.md
@@ -46,7 +46,7 @@ None.
 
 ### Cross-feature interactions
 
-- Listens to sidebar visibility events to know when sidebar is shown/hidden.
+- (Planned) Listens to sidebar visibility events to know when sidebar is shown/hidden.
 - Provides restored sidebar width to the sidebar renderer via event on startup.
 - Tracks window bounds changes from the main process.
 

--- a/docs/features/AppStateFeature.specs.md
+++ b/docs/features/AppStateFeature.specs.md
@@ -4,21 +4,21 @@
 
 The App State feature remembers certain UI layout settings between app launches.
 
-This includes the size of the Sidebar panel, the tab palette, and the window position/size.
+This includes the size of the Sidebar panel and the window position/size.
 
 ## Terminology
 
 - **App state**: user UI preferences that are restored on startup.
 - **Sidebar width**: the width of the Sidebar panel.
-- **Tab palette width**: the width of the tab palette overlay panel.
 
 ## Requirements
 
+- The Sidebar panel must have a draggable resize handle on its right edge.
 - When the user resizes the Sidebar panel, the new width must be saved.
 - The saved Sidebar width must be restored on startup.
-- When the user resizes the tab palette, the new width must be saved.
-- The tab palette should remain closed until the user opens it, but it should use the previously saved width when shown.
 - Window position and size must be persisted and restored on startup.
+- Saves must be debounced to avoid excessive disk writes during resize drags.
+- App state is stored via `DataStore.setSetting()` (JSON key-value).
 
 ## Workflows
 
@@ -30,14 +30,9 @@ This includes the size of the Sidebar panel, the tab palette, and the window pos
 
 ### Resize and persist Sidebar
 
-- Resize the Sidebar panel.
-- When resizing completes, the new width is saved and used next time the app starts.
-
-### Resize and persist tab palette
-
-- Open the tab palette.
-- Resize the tab palette.
-- When resizing completes, the new width is saved and used the next time the tab palette opens.
+- Drag the Sidebar resize handle.
+- The Sidebar width updates in real time during the drag.
+- When the drag ends, the new width is saved (debounced).
 
 ## Interactions
 
@@ -47,21 +42,26 @@ None.
 
 ### Mouse interactions
 
-- **Resize Sidebar**: Drag the Sidebar resize handle.
-- **Resize tab palette**: Drag the tab palette resize handle.
+- **Resize Sidebar**: Drag the Sidebar resize handle on the right edge of the sidebar.
+
+### Cross-feature interactions
+
+- Listens to sidebar visibility events to know when sidebar is shown/hidden.
+- Provides restored sidebar width to the sidebar renderer via event on startup.
+- Tracks window bounds changes from the main process.
 
 ## Commands & Events
 
 ### Commands
 
 - `app-state:save` — Persist current app state to disk.
+- `app-state:set-sidebar-width` — Set sidebar width (from resize handle drag). Payload: `{ width: number }`.
 
 ### Events
 
-- `app-state:restored` — App state was restored on startup. Payload: `{ state: AppState }`.
+- `app-state:restored` — App state was restored on startup. Payload: `{ sidebarWidth: number; windowBounds: { x: number; y: number; width: number; height: number } }`.
+- `app-state:sidebar-width-changed` — Sidebar width changed. Payload: `{ width: number }`.
 
 ## Unresolved Issues
 
-- **Storage mechanism**: Should app state be stored in the SQLite database or in a separate JSON file? JSON is simpler for key-value layout data; SQLite is already used for structured data.
-- **Multi-window state**: If multiple windows are open, which window's position/size is saved? Should each window's state be tracked independently?
-- **Debouncing saves**: Resize events fire frequently. The save must be debounced to avoid excessive disk writes.
+- **Multi-window state**: If multiple windows are open, which window's position/size is saved? For now, save the last-focused window's bounds.

--- a/src/features/app-state/app-state.feature.ts
+++ b/src/features/app-state/app-state.feature.ts
@@ -1,0 +1,7 @@
+import { registerFeature } from "../../renderer/src/Shell";
+import { subscribeToEvents } from "./app-state.store";
+
+registerFeature({
+  name: "app-state",
+  subscribeToEvents,
+});

--- a/src/features/app-state/app-state.main.ts
+++ b/src/features/app-state/app-state.main.ts
@@ -1,0 +1,124 @@
+import type { CommandBus } from "../../bus/command-bus";
+import type { EventBus } from "../../bus/event-bus";
+import type { DataStore } from "../../data/types";
+import type { Platform } from "../../platform/types";
+import type { Bounds, WindowId } from "../../shared/types";
+import {
+  APP_STATE_RESTORED,
+  APP_STATE_SAVE,
+  APP_STATE_SET_SIDEBAR_WIDTH,
+  APP_STATE_SIDEBAR_WIDTH_CHANGED,
+  type AppStateCommands,
+  type AppStateEvents,
+  DEFAULT_SIDEBAR_WIDTH,
+  DEFAULT_WINDOW_BOUNDS,
+  MAX_SIDEBAR_WIDTH,
+  MIN_SIDEBAR_WIDTH,
+  type PersistedAppState,
+} from "./app-state.shared";
+
+const SAVE_SETTING_KEY = "app-state";
+const DEBOUNCE_MS = 500;
+
+interface Deps {
+  commands: CommandBus<AppStateCommands>;
+  events: EventBus<AppStateEvents>;
+  platform: Platform;
+  dataStore: DataStore;
+  getActiveWindowId: () => WindowId | undefined;
+}
+
+let current: PersistedAppState;
+let saveTimer: ReturnType<typeof setTimeout> | undefined;
+
+function clampSidebarWidth(width: number): number {
+  return Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, Math.round(width)));
+}
+
+function scheduleSave(dataStore: DataStore): void {
+  if (saveTimer !== undefined) clearTimeout(saveTimer);
+  saveTimer = setTimeout(() => {
+    saveTimer = undefined;
+    dataStore.setSetting(SAVE_SETTING_KEY, current).catch(console.error);
+  }, DEBOUNCE_MS);
+}
+
+function flushSave(dataStore: DataStore): void {
+  if (saveTimer !== undefined) {
+    clearTimeout(saveTimer);
+    saveTimer = undefined;
+  }
+  dataStore.setSetting(SAVE_SETTING_KEY, current).catch(console.error);
+}
+
+export function register({ commands, events, dataStore }: Deps): void {
+  current = {
+    sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
+    windowBounds: { ...DEFAULT_WINDOW_BOUNDS },
+  };
+
+  commands.handle(APP_STATE_SET_SIDEBAR_WIDTH, async ({ width }) => {
+    const clamped = clampSidebarWidth(width);
+    if (clamped === current.sidebarWidth) return;
+    current.sidebarWidth = clamped;
+    events.emit(APP_STATE_SIDEBAR_WIDTH_CHANGED, { width: clamped });
+    scheduleSave(dataStore);
+  });
+
+  commands.handle(APP_STATE_SAVE, async () => {
+    flushSave(dataStore);
+  });
+}
+
+/** Call from main index.ts on window move/resize (debounced save). */
+export function onWindowBoundsChanged(bounds: Bounds, dataStore: DataStore): void {
+  current.windowBounds = { ...bounds };
+  scheduleSave(dataStore);
+}
+
+/** Load persisted state. Returns bounds for createWindow. */
+export async function loadPersistedState(
+  dataStore: DataStore,
+  getDisplayBounds: () => Bounds[],
+): Promise<PersistedAppState> {
+  const saved = await dataStore.getSetting<PersistedAppState>(SAVE_SETTING_KEY);
+  if (saved) {
+    current.sidebarWidth = clampSidebarWidth(saved.sidebarWidth ?? DEFAULT_SIDEBAR_WIDTH);
+    current.windowBounds = validateBounds(saved.windowBounds, getDisplayBounds());
+  }
+  return { ...current };
+}
+
+export function start({ events }: Deps): void {
+  events.emit(APP_STATE_RESTORED, {
+    sidebarWidth: current.sidebarWidth,
+    windowBounds: { ...current.windowBounds },
+  });
+}
+
+/** Ensure window bounds are visible on at least one display. */
+function validateBounds(bounds: Bounds | undefined, displays: Bounds[]): Bounds {
+  if (!bounds || !bounds.width || !bounds.height) return { ...DEFAULT_WINDOW_BOUNDS };
+  if (displays.length === 0) return bounds;
+
+  // Check if at least 100px of the window is visible on any display
+  const minVisible = 100;
+  const isVisible = displays.some(
+    (d) =>
+      bounds.x + minVisible > d.x &&
+      bounds.x < d.x + d.width - minVisible &&
+      bounds.y + minVisible > d.y &&
+      bounds.y < d.y + d.height - minVisible,
+  );
+
+  if (isVisible) return bounds;
+
+  // Window is off-screen — keep size, center on primary display
+  const primary = displays[0] ?? { x: 0, y: 0, width: 1920, height: 1080 };
+  return {
+    x: primary.x + Math.round((primary.width - bounds.width) / 2),
+    y: primary.y + Math.round((primary.height - bounds.height) / 2),
+    width: bounds.width,
+    height: bounds.height,
+  };
+}

--- a/src/features/app-state/app-state.main.ts
+++ b/src/features/app-state/app-state.main.ts
@@ -98,7 +98,14 @@ export function start({ events }: Deps): void {
 
 /** Ensure window bounds are visible on at least one display. */
 function validateBounds(bounds: Bounds | undefined, displays: Bounds[]): Bounds {
-  if (!bounds || !bounds.width || !bounds.height) return { ...DEFAULT_WINDOW_BOUNDS };
+  if (
+    !bounds ||
+    !Number.isFinite(bounds.width) ||
+    !Number.isFinite(bounds.height) ||
+    bounds.width <= 0 ||
+    bounds.height <= 0
+  )
+    return { ...DEFAULT_WINDOW_BOUNDS };
   if (displays.length === 0) return bounds;
 
   // Check if at least 100px of the window is visible on any display

--- a/src/features/app-state/app-state.shared.ts
+++ b/src/features/app-state/app-state.shared.ts
@@ -1,0 +1,47 @@
+import type { Bounds } from "../../shared/types";
+
+// ── Command names ────────────────────────────────────────────────
+export const APP_STATE_SAVE = "app-state:save" as const;
+export const APP_STATE_SET_SIDEBAR_WIDTH = "app-state:set-sidebar-width" as const;
+
+// ── Event names ──────────────────────────────────────────────────
+export const APP_STATE_RESTORED = "app-state:restored" as const;
+export const APP_STATE_SIDEBAR_WIDTH_CHANGED = "app-state:sidebar-width-changed" as const;
+
+// ── Payload types ────────────────────────────────────────────────
+export interface AppStateRestoredEvent {
+  sidebarWidth: number;
+  windowBounds: Bounds;
+}
+
+export interface AppStateSidebarWidthChangedEvent {
+  width: number;
+}
+
+export interface SetSidebarWidthPayload {
+  width: number;
+}
+
+// ── Persisted shape ──────────────────────────────────────────────
+export interface PersistedAppState {
+  sidebarWidth: number;
+  windowBounds: Bounds;
+}
+
+// ── Defaults ─────────────────────────────────────────────────────
+export const DEFAULT_SIDEBAR_WIDTH = 240; // px (matches --sidebar-width: 15rem)
+export const MIN_SIDEBAR_WIDTH = 160;
+export const MAX_SIDEBAR_WIDTH = 480;
+export const DEFAULT_WINDOW_BOUNDS: Bounds = { x: 100, y: 100, width: 1200, height: 800 };
+
+// ── Command registry ─────────────────────────────────────────────
+export type AppStateCommands = {
+  [APP_STATE_SAVE]: { payload: undefined; response: undefined };
+  [APP_STATE_SET_SIDEBAR_WIDTH]: { payload: SetSidebarWidthPayload; response: undefined };
+};
+
+// ── Event registry ───────────────────────────────────────────────
+export type AppStateEvents = {
+  [APP_STATE_RESTORED]: AppStateRestoredEvent;
+  [APP_STATE_SIDEBAR_WIDTH_CHANGED]: AppStateSidebarWidthChangedEvent;
+};

--- a/src/features/app-state/app-state.store.ts
+++ b/src/features/app-state/app-state.store.ts
@@ -1,0 +1,40 @@
+import { create } from "zustand";
+import {
+  APP_STATE_RESTORED,
+  APP_STATE_SIDEBAR_WIDTH_CHANGED,
+  type AppStateRestoredEvent,
+  type AppStateSidebarWidthChangedEvent,
+  DEFAULT_SIDEBAR_WIDTH,
+} from "./app-state.shared";
+
+interface AppStateStoreState {
+  sidebarWidth: number;
+}
+
+export const useAppStateStore = create<AppStateStoreState>()(() => ({
+  sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
+}));
+
+export function subscribeToEvents(
+  onEvent: (name: string, callback: (payload: unknown) => void) => () => void,
+): () => void {
+  const unsubs: (() => void)[] = [];
+
+  unsubs.push(
+    onEvent(APP_STATE_RESTORED, (payload) => {
+      const { sidebarWidth } = payload as AppStateRestoredEvent;
+      useAppStateStore.setState({ sidebarWidth });
+    }),
+  );
+
+  unsubs.push(
+    onEvent(APP_STATE_SIDEBAR_WIDTH_CHANGED, (payload) => {
+      const { width } = payload as AppStateSidebarWidthChangedEvent;
+      useAppStateStore.setState({ sidebarWidth: width });
+    }),
+  );
+
+  return () => {
+    for (const unsub of unsubs) unsub();
+  };
+}

--- a/src/features/app-state/app-state.test.ts
+++ b/src/features/app-state/app-state.test.ts
@@ -84,14 +84,17 @@ describe("app-state:set-sidebar-width", () => {
 describe("app-state:save", () => {
   it("persists state to data store", async () => {
     vi.useFakeTimers();
-    const { commands, dataStore } = setup();
+    try {
+      const { commands, dataStore } = setup();
 
-    await commands.send(APP_STATE_SET_SIDEBAR_WIDTH, { width: 350 });
-    await commands.send(APP_STATE_SAVE, undefined);
+      await commands.send(APP_STATE_SET_SIDEBAR_WIDTH, { width: 350 });
+      await commands.send(APP_STATE_SAVE, undefined);
 
-    const saved = await dataStore.getSetting("app-state");
-    expect(saved).toEqual(expect.objectContaining({ sidebarWidth: 350 }));
-    vi.useRealTimers();
+      const saved = await dataStore.getSetting("app-state");
+      expect(saved).toEqual(expect.objectContaining({ sidebarWidth: 350 }));
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/features/app-state/app-state.test.ts
+++ b/src/features/app-state/app-state.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from "vitest";
+import { CommandBus } from "../../bus/command-bus";
+import { EventBus } from "../../bus/event-bus";
+import { MemoryDataStore } from "../../data/memory-store";
+import type { Bounds, WindowId } from "../../shared/types";
+import { createMockPlatform } from "../../test-utils";
+import { loadPersistedState, register, start } from "./app-state.main";
+import {
+  APP_STATE_RESTORED,
+  APP_STATE_SAVE,
+  APP_STATE_SET_SIDEBAR_WIDTH,
+  APP_STATE_SIDEBAR_WIDTH_CHANGED,
+  type AppStateCommands,
+  type AppStateEvents,
+  DEFAULT_SIDEBAR_WIDTH,
+  DEFAULT_WINDOW_BOUNDS,
+  MAX_SIDEBAR_WIDTH,
+  MIN_SIDEBAR_WIDTH,
+} from "./app-state.shared";
+
+const WINDOW_ID = "win-1" as WindowId;
+const DISPLAY_BOUNDS: Bounds[] = [{ x: 0, y: 0, width: 1920, height: 1080 }];
+
+function setup() {
+  const commands = new CommandBus<AppStateCommands>();
+  const events = new EventBus<AppStateEvents>();
+  const platform = createMockPlatform();
+  const dataStore = new MemoryDataStore();
+
+  const deps = {
+    commands,
+    events,
+    platform,
+    dataStore,
+    getActiveWindowId: () => WINDOW_ID,
+  };
+
+  register(deps);
+  return { commands, events, platform, dataStore, deps };
+}
+
+describe("app-state:set-sidebar-width", () => {
+  it("emits sidebar-width-changed with clamped value", async () => {
+    const { commands, events } = setup();
+    const listener = vi.fn();
+    events.on(APP_STATE_SIDEBAR_WIDTH_CHANGED, listener);
+
+    await commands.send(APP_STATE_SET_SIDEBAR_WIDTH, { width: 300 });
+
+    expect(listener).toHaveBeenCalledWith({ width: 300 });
+  });
+
+  it("clamps below minimum", async () => {
+    const { commands, events } = setup();
+    const listener = vi.fn();
+    events.on(APP_STATE_SIDEBAR_WIDTH_CHANGED, listener);
+
+    await commands.send(APP_STATE_SET_SIDEBAR_WIDTH, { width: 50 });
+
+    expect(listener).toHaveBeenCalledWith({ width: MIN_SIDEBAR_WIDTH });
+  });
+
+  it("clamps above maximum", async () => {
+    const { commands, events } = setup();
+    const listener = vi.fn();
+    events.on(APP_STATE_SIDEBAR_WIDTH_CHANGED, listener);
+
+    await commands.send(APP_STATE_SET_SIDEBAR_WIDTH, { width: 999 });
+
+    expect(listener).toHaveBeenCalledWith({ width: MAX_SIDEBAR_WIDTH });
+  });
+
+  it("does not emit when value unchanged", async () => {
+    const { commands, events } = setup();
+    const listener = vi.fn();
+    events.on(APP_STATE_SIDEBAR_WIDTH_CHANGED, listener);
+
+    await commands.send(APP_STATE_SET_SIDEBAR_WIDTH, { width: DEFAULT_SIDEBAR_WIDTH });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe("app-state:save", () => {
+  it("persists state to data store", async () => {
+    vi.useFakeTimers();
+    const { commands, dataStore } = setup();
+
+    await commands.send(APP_STATE_SET_SIDEBAR_WIDTH, { width: 350 });
+    await commands.send(APP_STATE_SAVE, undefined);
+
+    const saved = await dataStore.getSetting("app-state");
+    expect(saved).toEqual(expect.objectContaining({ sidebarWidth: 350 }));
+    vi.useRealTimers();
+  });
+});
+
+describe("loadPersistedState", () => {
+  it("returns defaults when no persisted state", async () => {
+    // Call setup() to reset module-level state
+    const { dataStore } = setup();
+    const state = await loadPersistedState(dataStore, () => DISPLAY_BOUNDS);
+
+    expect(state.sidebarWidth).toBe(DEFAULT_SIDEBAR_WIDTH);
+    expect(state.windowBounds).toEqual(DEFAULT_WINDOW_BOUNDS);
+  });
+
+  it("restores persisted sidebar width", async () => {
+    const { dataStore } = setup();
+    await dataStore.setSetting("app-state", {
+      sidebarWidth: 300,
+      windowBounds: { x: 50, y: 50, width: 1000, height: 700 },
+    });
+
+    const state = await loadPersistedState(dataStore, () => DISPLAY_BOUNDS);
+
+    expect(state.sidebarWidth).toBe(300);
+    expect(state.windowBounds).toEqual({ x: 50, y: 50, width: 1000, height: 700 });
+  });
+
+  it("clamps out-of-range sidebar width", async () => {
+    const { dataStore } = setup();
+    await dataStore.setSetting("app-state", {
+      sidebarWidth: 9999,
+      windowBounds: DEFAULT_WINDOW_BOUNDS,
+    });
+
+    const state = await loadPersistedState(dataStore, () => DISPLAY_BOUNDS);
+
+    expect(state.sidebarWidth).toBe(MAX_SIDEBAR_WIDTH);
+  });
+
+  it("recenters window when off-screen", async () => {
+    const { dataStore } = setup();
+    await dataStore.setSetting("app-state", {
+      sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
+      windowBounds: { x: -5000, y: -5000, width: 1200, height: 800 },
+    });
+
+    const state = await loadPersistedState(dataStore, () => DISPLAY_BOUNDS);
+
+    expect(state.windowBounds.x).toBeGreaterThanOrEqual(0);
+    expect(state.windowBounds.y).toBeGreaterThanOrEqual(0);
+    expect(state.windowBounds.width).toBe(1200);
+    expect(state.windowBounds.height).toBe(800);
+  });
+});
+
+describe("start()", () => {
+  it("emits app-state:restored with current state", () => {
+    const { events, deps } = setup();
+    const listener = vi.fn();
+    events.on(APP_STATE_RESTORED, listener);
+
+    start(deps);
+
+    expect(listener).toHaveBeenCalledWith({
+      sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
+      windowBounds: DEFAULT_WINDOW_BOUNDS,
+    });
+  });
+
+  it("emits restored state after loading persisted data", async () => {
+    const { events, dataStore, deps } = setup();
+
+    await dataStore.setSetting("app-state", {
+      sidebarWidth: 280,
+      windowBounds: { x: 200, y: 100, width: 1400, height: 900 },
+    });
+    await loadPersistedState(dataStore, () => DISPLAY_BOUNDS);
+
+    const listener = vi.fn();
+    events.on(APP_STATE_RESTORED, listener);
+
+    start(deps);
+
+    expect(listener).toHaveBeenCalledWith({
+      sidebarWidth: 280,
+      windowBounds: { x: 200, y: 100, width: 1400, height: 900 },
+    });
+  });
+});

--- a/src/features/sidebar/sidebar-panel.test.tsx
+++ b/src/features/sidebar/sidebar-panel.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TabId, WorkspaceId } from "../../shared/types";
 import { makePinnedTab, makeTab, makeWorkspace } from "../../test-utils";
+import { useAppStateStore } from "../app-state/app-state.store";
 import type { PinnedTab } from "../pinned-tabs/pinned-tabs.shared";
 import { usePinnedTabsStore } from "../pinned-tabs/pinned-tabs.store";
 import type { Tab } from "../tabs/tabs.shared";
@@ -26,6 +27,7 @@ function setStores(
   opts: {
     visible?: boolean;
     announcement?: string;
+    sidebarWidth?: number;
     tabs?: Tab[];
     activeTabId?: TabId | null;
     pinnedTabs?: PinnedTab[];
@@ -33,6 +35,10 @@ function setStores(
     activeWorkspaceId?: WorkspaceId | null;
   } = {},
 ) {
+  useAppStateStore.setState({
+    sidebarWidth: opts.sidebarWidth ?? 240,
+  });
+
   useSidebarStore.setState({
     visible: opts.visible ?? true,
     announcement: opts.announcement ?? "",

--- a/src/features/sidebar/sidebar-panel.test.tsx
+++ b/src/features/sidebar/sidebar-panel.test.tsx
@@ -61,8 +61,9 @@ function getNav() {
 }
 
 function getOuterDiv() {
-  const el = getNav().parentElement;
-  if (!el) throw new Error("Sidebar nav has no parent element");
+  // Structure: outer (width/overflow) > inner (relative flex) > nav
+  const el = getNav().parentElement?.parentElement;
+  if (!el) throw new Error("Sidebar nav has no outer container");
   return el;
 }
 
@@ -89,7 +90,7 @@ describe("SidebarPanel", () => {
     it("has sidebar width when visible", () => {
       setStores({ visible: true });
       render(<SidebarPanel />);
-      expect(getOuterDiv().style.width).toBe("var(--sidebar-width)");
+      expect(getOuterDiv().style.width).toBe("240px");
     });
 
     it("has zero width when collapsed", () => {

--- a/src/features/sidebar/sidebar.renderer.tsx
+++ b/src/features/sidebar/sidebar.renderer.tsx
@@ -1658,8 +1658,12 @@ export function SidebarPanel() {
             if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
               e.preventDefault();
               const delta = e.key === "ArrowRight" ? 10 : -10;
+              const width = Math.max(
+                MIN_SIDEBAR_WIDTH,
+                Math.min(MAX_SIDEBAR_WIDTH, resize.width + delta),
+              );
               window.chiaroscuro.sendCommand(APP_STATE_SET_SIDEBAR_WIDTH, {
-                width: resize.width + delta,
+                width,
               });
             }
           }}

--- a/src/features/sidebar/sidebar.renderer.tsx
+++ b/src/features/sidebar/sidebar.renderer.tsx
@@ -2,6 +2,13 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { type ContextMenuItem, useContextMenu } from "../../renderer/src/components/ContextMenu";
 import { Icon } from "../../renderer/src/components/Icon";
 import type { FolderId, TabId, WorkspaceId } from "../../shared/types";
+import {
+  APP_STATE_SET_SIDEBAR_WIDTH,
+  MAX_SIDEBAR_WIDTH,
+  MIN_SIDEBAR_WIDTH,
+} from "../app-state/app-state.shared";
+// shell-composite: read-only cross-feature store access
+import { useAppStateStore } from "../app-state/app-state.store";
 import type { Folder } from "../folders/folders.shared";
 import {
   FOLDERS_CREATE,
@@ -1378,9 +1385,55 @@ function TabSection({
 
 // ── Main Component ──────────────────────────────────────────────
 
+function useSidebarResize(sidebarWidth: number) {
+  const [dragWidth, setDragWidth] = useState<number | null>(null);
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(0);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault();
+      startXRef.current = e.clientX;
+      startWidthRef.current = sidebarWidth;
+      setDragWidth(sidebarWidth);
+
+      const target = e.currentTarget as HTMLElement;
+      target.setPointerCapture(e.pointerId);
+    },
+    [sidebarWidth],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (dragWidth === null) return;
+      const delta = e.clientX - startXRef.current;
+      const newWidth = Math.max(
+        MIN_SIDEBAR_WIDTH,
+        Math.min(MAX_SIDEBAR_WIDTH, startWidthRef.current + delta),
+      );
+      setDragWidth(newWidth);
+    },
+    [dragWidth],
+  );
+
+  const onPointerUp = useCallback(() => {
+    if (dragWidth === null) return;
+    const finalWidth = Math.round(dragWidth);
+    setDragWidth(null);
+    window.chiaroscuro.sendCommand(APP_STATE_SET_SIDEBAR_WIDTH, { width: finalWidth });
+  }, [dragWidth]);
+
+  return {
+    width: dragWidth ?? sidebarWidth,
+    isResizing: dragWidth !== null,
+    handlers: { onPointerDown, onPointerMove, onPointerUp },
+  };
+}
+
 export function SidebarPanel() {
   const visible = useSidebarStore((s) => s.visible);
   const announcement = useSidebarStore((s) => s.announcement);
+  const sidebarWidth = useAppStateStore((s) => s.sidebarWidth);
   const tabs = useTabsStore((s) => s.tabs);
   const activeTabId = useTabsStore((s) => s.activeTabId);
   const pinnedTabs = usePinnedTabsStore((s) => s.pinnedTabs);
@@ -1472,6 +1525,8 @@ export function SidebarPanel() {
   // Context menu
   const { open: openContextMenu, portal: contextMenuPortal } = useContextMenu();
 
+  const resize = useSidebarResize(sidebarWidth);
+
   const handleSidebarContextMenu = (e: React.MouseEvent) => {
     // Only fire if right-clicking empty sidebar area (not a tab/folder)
     if ((e.target as HTMLElement).closest("[data-tab-id], [data-folder-id], [data-pinned-tab]")) {
@@ -1489,107 +1544,134 @@ export function SidebarPanel() {
     );
   };
 
+  const sidebarPx = `${resize.width}px`;
+
   return (
     <div
       className="shrink-0 overflow-hidden"
       style={{
-        width: visible ? "var(--sidebar-width)" : "0",
-        transition: "width var(--duration-normal) var(--ease-in-out)",
+        width: visible ? sidebarPx : "0",
+        transition: resize.isResizing ? "none" : "width var(--duration-normal) var(--ease-in-out)",
       }}
     >
-      <nav
-        aria-label="Sidebar"
-        className="flex flex-col overflow-hidden h-full"
-        style={{ width: "var(--sidebar-width)" }}
-        onDragStart={() => setIsDragging(true)}
-        onDragEnd={() => {
-          setIsDragging(false);
-          dragTabIdRef.current = null;
-          dragFolderIdRef.current = null;
-        }}
-        onContextMenu={handleSidebarContextMenu}
-      >
-        <div className="sr-only" aria-live="polite" aria-atomic="true">
-          {announcement}
-        </div>
+      <div className="relative flex h-full" style={{ width: sidebarPx }}>
+        <nav
+          aria-label="Sidebar"
+          className="flex flex-col overflow-hidden h-full flex-1"
+          onDragStart={() => setIsDragging(true)}
+          onDragEnd={() => {
+            setIsDragging(false);
+            dragTabIdRef.current = null;
+            dragFolderIdRef.current = null;
+          }}
+          onContextMenu={handleSidebarContextMenu}
+        >
+          <div className="sr-only" aria-live="polite" aria-atomic="true">
+            {announcement}
+          </div>
 
-        {pinnedTabs.length > 0 && (
-          <PinnedTabsStrip
-            pinnedTabs={pinnedTabs}
-            tabs={tabs}
-            activeTabId={activeTabId}
-            onContextMenu={openContextMenu}
-          />
-        )}
-        {contextMenuPortal}
+          {pinnedTabs.length > 0 && (
+            <PinnedTabsStrip
+              pinnedTabs={pinnedTabs}
+              tabs={tabs}
+              activeTabId={activeTabId}
+              onContextMenu={openContextMenu}
+            />
+          )}
+          {contextMenuPortal}
 
-        <div className="flex-1 overflow-y-auto">
-          <div style={{ position: "relative", overflow: "hidden" }}>
-            {/* Exiting workspace tabs (slide out) */}
-            {wsTransition && prevTabs && (
+          <div className="flex-1 overflow-y-auto">
+            <div style={{ position: "relative", overflow: "hidden" }}>
+              {/* Exiting workspace tabs (slide out) */}
+              {wsTransition && prevTabs && (
+                <div
+                  key={`exit-${wsTransition.fromWorkspaceId}`}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    willChange: "transform, opacity",
+                    animation: `${wsTransition.direction === "right" ? "ws-out-left" : "ws-out-right"} ${WS_SLIDE_MS}ms cubic-bezier(0.4, 0, 0.2, 1) forwards`,
+                  }}
+                >
+                  <TabSection
+                    bookmarked={prevTabs.bookmarked}
+                    bookmarkedTree={prevTabs.bookmarkedTree}
+                    ephemeral={prevTabs.ephemeral}
+                    activeTabId={null}
+                    exitingIds={new Set()}
+                    dragTabIdRef={dragTabIdRef}
+                    dragFolderIdRef={dragFolderIdRef}
+                    isDragging={false}
+                    onClearEphemeral={() => {}}
+                    disableEntryAnimation
+                    renamingFolderId={null}
+                  />
+                </div>
+              )}
+              {/* Current workspace tabs (slide in) */}
               <div
-                key={`exit-${wsTransition.fromWorkspaceId}`}
-                style={{
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                  right: 0,
-                  willChange: "transform, opacity",
-                  animation: `${wsTransition.direction === "right" ? "ws-out-left" : "ws-out-right"} ${WS_SLIDE_MS}ms cubic-bezier(0.4, 0, 0.2, 1) forwards`,
-                }}
+                key={activeWorkspaceId ?? undefined}
+                style={
+                  wsTransition
+                    ? {
+                        willChange: "transform, opacity",
+                        animation: `${wsTransition.direction === "right" ? "ws-in-from-right" : "ws-in-from-left"} ${WS_SLIDE_MS}ms cubic-bezier(0.4, 0, 0.2, 1) both`,
+                      }
+                    : undefined
+                }
               >
                 <TabSection
-                  bookmarked={prevTabs.bookmarked}
-                  bookmarkedTree={prevTabs.bookmarkedTree}
-                  ephemeral={prevTabs.ephemeral}
-                  activeTabId={null}
-                  exitingIds={new Set()}
+                  bookmarked={bookmarked}
+                  bookmarkedTree={bookmarkedTree}
+                  ephemeral={ephemeral}
+                  activeTabId={activeTabId}
+                  exitingIds={exitingIds}
                   dragTabIdRef={dragTabIdRef}
                   dragFolderIdRef={dragFolderIdRef}
-                  isDragging={false}
-                  onClearEphemeral={() => {}}
-                  disableEntryAnimation
-                  renamingFolderId={null}
+                  isDragging={isDragging}
+                  onClearEphemeral={handleClearEphemeral}
+                  disableEntryAnimation={!!wsTransition}
+                  renamingFolderId={renamingFolderId}
+                  onContextMenu={openContextMenu}
                 />
               </div>
-            )}
-            {/* Current workspace tabs (slide in) */}
-            <div
-              key={activeWorkspaceId ?? undefined}
-              style={
-                wsTransition
-                  ? {
-                      willChange: "transform, opacity",
-                      animation: `${wsTransition.direction === "right" ? "ws-in-from-right" : "ws-in-from-left"} ${WS_SLIDE_MS}ms cubic-bezier(0.4, 0, 0.2, 1) both`,
-                    }
-                  : undefined
-              }
-            >
-              <TabSection
-                bookmarked={bookmarked}
-                bookmarkedTree={bookmarkedTree}
-                ephemeral={ephemeral}
-                activeTabId={activeTabId}
-                exitingIds={exitingIds}
-                dragTabIdRef={dragTabIdRef}
-                dragFolderIdRef={dragFolderIdRef}
-                isDragging={isDragging}
-                onClearEphemeral={handleClearEphemeral}
-                disableEntryAnimation={!!wsTransition}
-                renamingFolderId={renamingFolderId}
-                onContextMenu={openContextMenu}
-              />
             </div>
           </div>
-        </div>
 
-        <WorkspaceSwitcher
-          workspaces={workspaces}
-          activeWorkspaceId={activeWorkspaceId}
-          editorMode={editorMode}
-          onEditorModeChange={setEditorMode}
+          <WorkspaceSwitcher
+            workspaces={workspaces}
+            activeWorkspaceId={activeWorkspaceId}
+            editorMode={editorMode}
+            onEditorModeChange={setEditorMode}
+          />
+        </nav>
+        {/* Invisible resize handle */}
+        <div
+          className="absolute top-0 right-0 h-full cursor-col-resize"
+          style={{ width: "4px" }}
+          onPointerDown={resize.handlers.onPointerDown}
+          onPointerMove={resize.handlers.onPointerMove}
+          onPointerUp={resize.handlers.onPointerUp}
+          onKeyDown={(e) => {
+            if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+              e.preventDefault();
+              const delta = e.key === "ArrowRight" ? 10 : -10;
+              window.chiaroscuro.sendCommand(APP_STATE_SET_SIDEBAR_WIDTH, {
+                width: resize.width + delta,
+              });
+            }
+          }}
+          aria-label="Resize sidebar"
+          role="separator"
+          aria-orientation="vertical"
+          aria-valuenow={resize.width}
+          aria-valuemin={MIN_SIDEBAR_WIDTH}
+          aria-valuemax={MAX_SIDEBAR_WIDTH}
+          tabIndex={0}
         />
-      </nav>
+      </div>
     </div>
   );
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,11 +1,18 @@
 import path from "node:path";
-import { BrowserWindow, Menu, app, ipcMain } from "electron";
+import { BrowserWindow, Menu, app, ipcMain, screen } from "electron";
 import { CommandBus } from "../bus/command-bus";
 import { EventBus } from "../bus/event-bus";
 import { bridgeBusToIpc } from "../bus/ipc-main-bridge";
 import type { MergeRegistries } from "../bus/types";
 import { createDataStore } from "../data/store";
 import type { DataStore } from "../data/types";
+import {
+  loadPersistedState,
+  onWindowBoundsChanged,
+  register as registerAppState,
+  start as startAppState,
+} from "../features/app-state/app-state.main";
+import type { AppStateCommands, AppStateEvents } from "../features/app-state/app-state.shared";
 import {
   register as registerCommandPalette,
   start as startCommandPalette,
@@ -75,6 +82,7 @@ const iconPath = path.join(__dirname, "../../resources", iconFile);
 // ── Merged bus types ──────────────────────────────────────────────
 type AllCommands = MergeRegistries<
   [
+    AppStateCommands,
     WindowChromeCommands,
     TabsCommands,
     WorkspacesCommands,
@@ -91,6 +99,7 @@ type AllCommands = MergeRegistries<
 
 type AllEvents = MergeRegistries<
   [
+    AppStateEvents,
     WindowChromeEvents,
     TabsEvents,
     WorkspacesEvents,
@@ -117,10 +126,14 @@ const platform = new ElectronPlatform(() => activeWindowId);
 const dataDir = process.env.DATA_DIR ?? path.join(app.getPath("userData"), "data");
 const dataStore: DataStore = createDataStore(dataDir);
 
-function createWindow(): void {
+function createWindow(windowBounds?: {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}): void {
   const win = new BrowserWindow({
-    width: 1200,
-    height: 800,
+    ...(windowBounds ?? { width: 1200, height: 800 }),
     icon: iconPath,
     titleBarStyle: "hidden",
     backgroundMaterial: "acrylic",
@@ -142,6 +155,19 @@ function createWindow(): void {
   win.on("unmaximize", () => {
     events.emit("window:maximized-changed", { maximized: false });
   });
+
+  // Track window bounds for app-state persistence
+  let boundsTimer: ReturnType<typeof setTimeout> | undefined;
+  const trackBounds = () => {
+    if (boundsTimer) clearTimeout(boundsTimer);
+    boundsTimer = setTimeout(() => {
+      if (!win.isMaximized() && !win.isMinimized()) {
+        onWindowBoundsChanged(win.getBounds(), dataStore);
+      }
+    }, 200);
+  };
+  win.on("move", trackBounds);
+  win.on("resize", trackBounds);
 
   if (process.env.ELECTRON_RENDERER_URL) {
     win.loadURL(process.env.ELECTRON_RENDERER_URL);
@@ -170,6 +196,7 @@ app.whenReady().then(async () => {
   await dataStore.initialize();
 
   // Phase 1: register all command handlers
+  registerAppState(deps);
   registerWindowChrome(deps);
   registerTabs(deps);
   registerWorkspaces(deps);
@@ -182,10 +209,14 @@ app.whenReady().then(async () => {
   registerFolders(deps);
   registerZoom(deps);
 
+  // Load persisted layout state before creating the window
+  const getDisplayBounds = () => screen.getAllDisplays().map((d) => d.workArea);
+  const appState = await loadPersistedState(dataStore, getDisplayBounds);
+
   // Bridge bus to IPC (once, before any window creation)
   bridgeBusToIpc(commands, events, () => BrowserWindow.getAllWindows());
 
-  createWindow();
+  createWindow(appState.windowBounds);
   if (activeWindowId && process.env.NODE_ENV !== "test") {
     platform.initTooltipOverlay(activeWindowId);
     platform.initContextMenuOverlay(activeWindowId);
@@ -204,6 +235,7 @@ app.whenReady().then(async () => {
 
   // Phase 2: wait for renderer subscriptions, then emit initial state
   ipcMain.once("renderer:ready", async () => {
+    startAppState(deps);
     await startWorkspaces(deps);
     startWindowChrome(deps);
     const restoredTabs = await startTabs(deps);
@@ -223,6 +255,8 @@ app.whenReady().then(async () => {
 
 app.on("before-quit", () => {
   platform.deactivateShortcuts();
+  // Flush app-state immediately before data store teardown
+  commands.send("app-state:save", undefined).catch(console.error);
   dataStore.destroy().catch(console.error);
 });
 

--- a/src/platform/electron.ts
+++ b/src/platform/electron.ts
@@ -154,6 +154,19 @@ export class ElectronPlatform implements Platform {
     this.getWin(windowId)?.focus();
   }
 
+  getWindowBounds(windowId: WindowId): Bounds | undefined {
+    return this.getWin(windowId)?.getBounds();
+  }
+
+  setWindowBounds(windowId: WindowId, bounds: Bounds): void {
+    this.getWin(windowId)?.setBounds({
+      x: Math.round(bounds.x),
+      y: Math.round(bounds.y),
+      width: Math.round(bounds.width),
+      height: Math.round(bounds.height),
+    });
+  }
+
   // ── Tab/WebContentsView management ──────────────────────────────
 
   async createTab(windowId: WindowId, url: string): Promise<TabId> {

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -11,6 +11,8 @@ export interface Platform {
   unmaximizeWindow(windowId: WindowId): Promise<void>;
   isWindowMaximized(windowId: WindowId): boolean;
   focusWindow(windowId: WindowId): Promise<void>;
+  getWindowBounds(windowId: WindowId): Bounds | undefined;
+  setWindowBounds(windowId: WindowId, bounds: Bounds): void;
 
   // Tab/WebContentsView management
   createTab(windowId: WindowId, url: string): Promise<TabId>;

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,5 @@
 // Feature registrations — each import subscribes to events synchronously (phase 1)
+import "../../features/app-state/app-state.feature";
 import "../../features/window-chrome/window-chrome.feature";
 import "../../features/tabs/tabs.feature";
 import "../../features/workspaces/workspaces.feature";

--- a/src/test-utils/mock-platform.ts
+++ b/src/test-utils/mock-platform.ts
@@ -10,6 +10,8 @@ export function createMockPlatform(overrides: Partial<Platform> = {}): Platform 
     unmaximizeWindow: vi.fn(),
     isWindowMaximized: vi.fn(() => false),
     focusWindow: vi.fn(),
+    getWindowBounds: vi.fn(() => ({ x: 100, y: 100, width: 1200, height: 800 })),
+    setWindowBounds: vi.fn(),
     createTab: vi.fn(),
     closeTab: vi.fn(),
     navigateTab: vi.fn(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added draggable resize handle on the right edge of the sidebar for adjusting width
  * Application state—including sidebar width, window position, and size—is now automatically saved and restored when the app restarts
  * Window bounds are validated to ensure visibility; off-screen windows are recentered on the primary display

* **Tests**
  * Added comprehensive test suite for application state management and persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->