### PR TITLE
Isolate dev-mode userData from production

### DIFF
--- a/src/features/command-palette/command-palette.main.ts
+++ b/src/features/command-palette/command-palette.main.ts
@@ -108,8 +108,8 @@ export default defineFeature<Deps>({
         await commands.send("tabs:create", { url });
       }
 
-      // Auto-hide palette after execution
-      await commands.send(COMMAND_PALETTE_HIDE, undefined);
+      // Palette HTML sends command-palette:hide immediately after execute —
+      // doing it here too would race with a subsequent re-open.
     });
 
     commands.handle(COMMAND_PALETTE_SEARCH_VISITS, async (payload) => {

--- a/src/features/command-palette/command-palette.test.ts
+++ b/src/features/command-palette/command-palette.test.ts
@@ -126,16 +126,12 @@ describe("command-palette commands", () => {
   });
 
   describe("EXECUTE", () => {
-    it("creates new tab for search input, auto-hides", async () => {
-      const { commands, events } = setup();
+    it("creates new tab for search input", async () => {
+      const { commands } = setup();
       await commands.send(COMMAND_PALETTE_SHOW, undefined);
 
-      const hidden = vi.fn();
-      events.on(COMMAND_PALETTE_HIDDEN, hidden);
-
+      // Should not throw — palette HTML handles hide separately
       await commands.send(COMMAND_PALETTE_EXECUTE, { command: "hello world" });
-
-      expect(hidden).toHaveBeenCalled();
     });
 
     it("navigates current tab when inCurrentTab=true", async () => {

--- a/src/features/command-palette/command-palette.test.ts
+++ b/src/features/command-palette/command-palette.test.ts
@@ -130,8 +130,9 @@ describe("command-palette commands", () => {
       const { commands } = setup();
       await commands.send(COMMAND_PALETTE_SHOW, undefined);
 
-      // Should not throw — palette HTML handles hide separately
       await commands.send(COMMAND_PALETTE_EXECUTE, { command: "hello world" });
+
+      expect(tabCounter).toBe(1);
     });
 
     it("navigates current tab when inCurrentTab=true", async () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -179,6 +179,7 @@ let activeTabId: TabId | undefined;
 let activeWorkspaceId: WorkspaceId | undefined;
 
 const isDev = !!process.env.ELECTRON_RENDERER_URL;
+if (isDev) app.setPath("userData", path.join(app.getPath("userData"), "..", "chiaroscuro-dev"));
 const platform = new ElectronPlatform(() => activeWindowId);
 const dataDir = process.env.DATA_DIR ?? path.join(app.getPath("userData"), "data");
 const dataStore: DataStore = createDataStore(dataDir);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted command palette hide behavior to avoid races when reopening after execution, improving reliability of command execution and subsequent palette interactions.

* **Chores**
  * Development-only data path separated from production to keep development runs isolated from user data.

* **Tests**
  * Updated command-palette tests to reflect the new hide behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->