### PR TITLE
Lazy tab loading on restore

### DIFF
--- a/src/features/tabs/tabs.main.ts
+++ b/src/features/tabs/tabs.main.ts
@@ -112,6 +112,9 @@ let _contentBounds: Bounds = { x: 0, y: 0, width: 0, height: 0 };
 // fixedAddressDisabled is set.
 const fixedUrls = new Map<TabId, string>();
 
+// Tabs restored at startup that haven't loaded their URL yet (lazy loading).
+const unloadedTabs = new Set<TabId>();
+
 /** Spread a tab with its fixedUrl for event emission. */
 function tabSnapshot(tab: Tab): Tab {
   const fixedUrl = fixedUrls.get(tab.id);
@@ -353,6 +356,7 @@ export default defineFeature<Deps>({
       }
       tabs.delete(tabId);
       fixedUrls.delete(tabId);
+      unloadedTabs.delete(tabId);
 
       let activatedTabId: TabId | null = null;
       if (wasActive) {
@@ -385,6 +389,14 @@ export default defineFeature<Deps>({
         if (!prevTab?.builtIn) {
           platform.hideTab(previousTabId);
         }
+      }
+
+      // Load URL if this tab was restored lazily and hasn't loaded yet
+      if (unloadedTabs.has(tabId)) {
+        unloadedTabs.delete(tabId);
+        tab.loading = true;
+        await platform.navigateTab(tabId, tab.url);
+        events.emit("tab:loading-changed", { tabId, loading: true });
       }
 
       // Show new tab (skip platform calls for built-in tabs)
@@ -623,6 +635,7 @@ export default defineFeature<Deps>({
   teardown() {
     _state.reset();
     fixedUrls.clear();
+    unloadedTabs.clear();
   },
 });
 
@@ -662,14 +675,14 @@ export async function start(deps: Deps): Promise<void> {
   for (const pt of toRestore) {
     try {
       const tabId = pt.id as TabId;
-      await platform.createTab(windowId, pt.url, tabId);
+      await platform.createTab(windowId, pt.url, tabId, { lazy: true });
       const tab: Tab = {
         id: tabId,
         workspaceId: pt.workspaceId as WorkspaceId,
         url: pt.url,
         title: pt.title,
         favicon: pt.favicon,
-        loading: true,
+        loading: false,
         bookmarked: pt.bookmarked,
         lastAccessedAt: pt.lastAccessedAt,
         createdAt: pt.createdAt,
@@ -679,6 +692,7 @@ export async function start(deps: Deps): Promise<void> {
 
       tabs.set(tabId, tab);
       attachTabListeners(tabId);
+      unloadedTabs.add(tabId);
       if (pt.bookmarked) fixedUrls.set(tabId, pt.url);
 
       // Track first tab in active workspace for activation

--- a/src/features/tabs/tabs.test.ts
+++ b/src/features/tabs/tabs.test.ts
@@ -401,9 +401,84 @@ describe("start()", () => {
     feature.register(deps);
     await start(deps);
 
-    // Only 1 tab restored (bookmarked one), keeps its persisted ID
+    // Only 1 tab restored (bookmarked one), keeps its persisted ID, created lazily
     expect(platform.createTab).toHaveBeenCalledTimes(1);
-    expect(platform.createTab).toHaveBeenCalledWith(WIN_ID, "https://bookmarked.com", "old-1");
+    expect(platform.createTab).toHaveBeenCalledWith(WIN_ID, "https://bookmarked.com", "old-1", {
+      lazy: true,
+    });
+  });
+
+  it("loads tab URL on first activation (lazy loading)", async () => {
+    const dataStore = new MemoryDataStore();
+    const tabsColl = dataStore.collection("tabs");
+    const now = Date.now();
+
+    await tabsColl.insert({
+      id: "lazy-1",
+      workspaceId: WS_ID,
+      url: "https://lazy.com",
+      title: "Lazy",
+      favicon: "",
+      bookmarked: true,
+      lastAccessedAt: now,
+      createdAt: now,
+      order: 0,
+    });
+    await tabsColl.insert({
+      id: "lazy-2",
+      workspaceId: WS_ID,
+      url: "https://lazy2.com",
+      title: "Lazy2",
+      favicon: "",
+      bookmarked: true,
+      lastAccessedAt: now - 1000,
+      createdAt: now - 1000,
+      order: 1,
+    });
+
+    let newTabCounter = 0;
+    const commands = new CommandBus<AllCommands>();
+    const events = new EventBus<AllEvents>();
+    const platform = createMockPlatform({
+      createTab: vi.fn(
+        async (_wId: WindowId, _url: string, tabId?: TabId) =>
+          tabId ?? (`new-${++newTabCounter}` as TabId),
+      ),
+    });
+    let activeTabId: TabId | undefined;
+    const deps = {
+      commands,
+      events,
+      platform,
+      dataStore,
+      getActiveWindowId: () => WIN_ID as WindowId | undefined,
+      getActiveTabId: () => activeTabId,
+      setActiveTabId: (id: TabId | undefined) => {
+        activeTabId = id;
+      },
+      getActiveWorkspaceId: () => WS_ID as WorkspaceId | undefined,
+      isPinned: (id: TabId) => isPinned(id),
+      getCustomization: () => undefined as { fixedAddressDisabled: boolean } | undefined,
+      getFoldersForLevel: () =>
+        [] as { id: import("../../shared/types").FolderId; order: number }[],
+      setFolderOrder: () => {},
+    };
+    feature.register(deps);
+    await start(deps);
+
+    // First tab (lazy-1, MRU) was activated and navigated
+    expect(platform.navigateTab).toHaveBeenCalledWith("lazy-1", "https://lazy.com");
+    // Second tab was NOT navigated (still lazy)
+    expect(platform.navigateTab).not.toHaveBeenCalledWith("lazy-2", "https://lazy2.com");
+
+    // Now activate the second tab — should trigger navigation
+    await commands.send(TABS_ACTIVATE, { tabId: "lazy-2" as TabId });
+    expect(platform.navigateTab).toHaveBeenCalledWith("lazy-2", "https://lazy2.com");
+
+    // Re-activating should NOT navigate again
+    (platform.navigateTab as ReturnType<typeof vi.fn>).mockClear();
+    await commands.send(TABS_ACTIVATE, { tabId: "lazy-1" as TabId });
+    expect(platform.navigateTab).not.toHaveBeenCalled();
   });
 
   it("does nothing when no persisted tabs", async () => {

--- a/src/platform/electron.ts
+++ b/src/platform/electron.ts
@@ -449,7 +449,12 @@ export class ElectronPlatform implements Platform {
 
   // ── Tab/WebContentsView management ──────────────────────────────
 
-  async createTab(windowId: WindowId, url: string, existingTabId?: TabId): Promise<TabId> {
+  async createTab(
+    windowId: WindowId,
+    url: string,
+    existingTabId?: TabId,
+    options?: { lazy?: boolean },
+  ): Promise<TabId> {
     const win = this.getWin(windowId);
     if (!win) throw new Error("No window found");
 
@@ -545,8 +550,10 @@ export class ElectronPlatform implements Platform {
       this.zoomIpcHooked = true;
     }
 
-    if (!isAllowedUrl(url, "internal")) throw new Error(`Blocked URL scheme: ${url}`);
-    view.webContents.loadURL(url);
+    if (!options?.lazy) {
+      if (!isAllowedUrl(url, "internal")) throw new Error(`Blocked URL scheme: ${url}`);
+      view.webContents.loadURL(url);
+    }
 
     return tabId;
   }

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -32,7 +32,12 @@ export interface Platform {
   setWindowBounds(windowId: WindowId, bounds: Bounds): void;
 
   // Tab/WebContentsView management
-  createTab(windowId: WindowId, url: string, tabId?: TabId): Promise<TabId>;
+  createTab(
+    windowId: WindowId,
+    url: string,
+    tabId?: TabId,
+    options?: { lazy?: boolean },
+  ): Promise<TabId>;
   closeTab(tabId: TabId): Promise<void>;
   navigateTab(tabId: TabId, url: string): Promise<void>;
   getTabUrl(tabId: TabId): string | undefined;


### PR DESCRIPTION
Restored tabs skip URL load until first activated. Reduces startup resource usage by only navigating tabs when the user switches to them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented lazy loading for restored tabs: tabs recovered from previous sessions now defer content loading until first activation, improving startup performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->