### PR TITLE
Fix file:// URLs in command palette

### DIFF
--- a/src/features/command-palette/resolve-input.test.ts
+++ b/src/features/command-palette/resolve-input.test.ts
@@ -43,6 +43,16 @@ describe("resolveInputDetailed", () => {
     expect(result).toEqual({ type: "url", url: "http://localhost:3000" });
   });
 
+  it("explicit file:// → type:url", () => {
+    const result = resolveInputDetailed(
+      "file:///C:/Users/morten/Documents/Vampire/Kronstadt%20PC%20version.pdf",
+    );
+    expect(result).toEqual({
+      type: "url",
+      url: "file:///C:/Users/morten/Documents/Vampire/Kronstadt%20PC%20version.pdf",
+    });
+  });
+
   it("text with spaces → default provider search", () => {
     const result = resolveInputDetailed("hello world");
     expect(result).toMatchObject({

--- a/src/features/command-palette/resolve-input.ts
+++ b/src/features/command-palette/resolve-input.ts
@@ -137,7 +137,7 @@ export function resolveInputDetailed(
   }
 
   // Has explicit protocol
-  if (/^https?:\/\//i.test(trimmed)) {
+  if (/^(?:https?|file):\/\//i.test(trimmed)) {
     return { type: "url", url: trimmed };
   }
 


### PR DESCRIPTION
resolveInput only matched http(s) protocols, so file:// URLs fell through to the "has dot" branch which prepended https://.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced command palette input resolution to recognize and properly handle file-based URIs alongside existing web URLs.

* **Tests**
  * Added test coverage for file URI parsing in command input resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->