### PR TITLE
Tab context menu for web content

### DIFF
--- a/docs/features/TabContextMenuFeature.specs.md
+++ b/docs/features/TabContextMenuFeature.specs.md
@@ -1,0 +1,88 @@
+# Specification for Tab Context Menu Feature
+
+## Overview
+
+Custom context menu for right-clicking content within tab web pages. Shows context-aware actions (copy, download, search) depending on what element is under the cursor. Defers to the website's own context menu when the page handles the event.
+
+## Terminology
+
+- **Context params**: Electron's `ContextMenuParams` from the WebContents `context-menu` event — contains info about what was right-clicked (link URL, image URL, selected text, media type, etc.).
+- **Context type**: Derived from params — one of `image`, `link`, `selection`, or `none`.
+
+## Requirements
+
+- When a user right-clicks inside a tab, detect what is under the cursor.
+- If the website handles the `contextmenu` event (prevents default), do nothing — let the page's own menu show.
+- If the website does not handle `contextmenu`, show a custom context menu overlay with context-appropriate actions.
+- **Image context**: Show "Copy image" and "Download image" actions.
+- **Selected text context**: Show "Copy" and "Search with [provider]" actions. The search provider is the user's configured default.
+- **Link context**: Show "Copy link" actions.
+- Contexts can overlap (e.g., selected text on a link). Show combined items when multiple contexts apply.
+- Use the same native overlay context menu component used by the sidebar.
+- Use Font Awesome icons: `fa-copy` for all copy operations, `fa-download` for download, `fa-magnifying-glass` for search.
+- Actions execute in the main process (clipboard write, download trigger, tab navigation for search).
+
+## Workflows
+
+### Right-click on image
+
+1. User right-clicks an image in a tab.
+2. Custom context menu appears with "Copy image" and "Download image".
+3. "Copy image" writes the image to clipboard (as image data, not URL).
+4. "Download image" triggers a download of the image URL.
+
+### Right-click on selected text
+
+1. User selects text, then right-clicks.
+2. Custom context menu appears with "Copy" and "Search with Google" (or configured default provider).
+3. "Copy" writes selected text to clipboard.
+4. "Search" opens a new tab with the search query.
+
+### Right-click on link
+
+1. User right-clicks a hyperlink.
+2. Custom context menu appears with "Copy link".
+3. "Copy link" writes the link URL to clipboard.
+
+### Right-click on page background
+
+1. User right-clicks empty area with no selection.
+2. No custom context menu shown (nothing actionable).
+
+### Website has own context menu
+
+1. User right-clicks in a page that handles `contextmenu` (e.g., Google Docs, VS Code web).
+2. The page's own menu appears. Our custom menu does not show.
+
+## Interactions
+
+### Mouse interactions
+
+- **Right-click**: Shows context menu at cursor position.
+- **Left-click on menu item**: Executes the action and dismisses menu.
+- **Click outside menu**: Dismisses menu.
+- **Escape key**: Dismisses menu.
+
+### Cross-feature interactions
+
+- **context-menu feature**: Uses `CONTEXT_MENU_SHOW` command to display the overlay.
+- **tabs feature**: Listens to `TABS_CREATED` to attach `context-menu` event listeners per tab. Uses `TABS_CLOSED` for cleanup. Uses `TABS_CREATE` for search action.
+- **settings feature**: Reads `SETTINGS_GET` to determine default search provider.
+
+## Commands & Events
+
+### Commands
+
+- `tab-context-menu:copy-text` — Copy text to clipboard. Payload: `{ text: string }`.
+- `tab-context-menu:copy-image` — Copy image to clipboard from URL. Payload: `{ url: string; tabId: TabId }`.
+- `tab-context-menu:download-image` — Download image. Payload: `{ url: string; tabId: TabId }`.
+- `tab-context-menu:search-text` — Search selected text with default provider. Payload: `{ text: string }`.
+
+### Events
+
+None — all actions are fire-and-forget commands with no state to sync.
+
+## Unresolved Issues
+
+- Should "Copy image" copy the image data (bitmap) or the image URL? Copying data is more useful but requires fetching. → Decision: copy as image data (nativeImage).
+- Should we add "Open link in new tab" action for links? → Deferred to future iteration.

--- a/docs/features/TabContextMenuFeature.specs.md
+++ b/docs/features/TabContextMenuFeature.specs.md
@@ -74,7 +74,7 @@ Custom context menu for right-clicking content within tab web pages. Shows conte
 ### Commands
 
 - `tab-context-menu:copy-text` — Copy text to clipboard. Payload: `{ text: string }`.
-- `tab-context-menu:copy-image` — Copy image to clipboard from URL. Payload: `{ url: string; tabId: TabId }`.
+- `tab-context-menu:copy-image` — Copy image to clipboard at coordinates. Payload: `{ tabId: TabId; x: number; y: number }`.
 - `tab-context-menu:download-image` — Download image. Payload: `{ url: string; tabId: TabId }`.
 - `tab-context-menu:search-text` — Search selected text with default provider. Payload: `{ text: string }`.
 

--- a/src/features/tab-context-menu/tab-context-menu.main.ts
+++ b/src/features/tab-context-menu/tab-context-menu.main.ts
@@ -42,9 +42,11 @@ const CONTEXT_MENU_DETECT_SCRIPT = `
     if (window.__chiaroscuroCtxMenuPatched) return;
     window.__chiaroscuroCtxMenuPatched = true;
     window.__chiaroscuroCtxMenuPrevented = false;
-    document.addEventListener('contextmenu', (e) => {
-      window.__chiaroscuroCtxMenuPrevented = e.defaultPrevented;
-    }, { capture: false });
+    window.addEventListener('contextmenu', (e) => {
+      queueMicrotask(() => {
+        window.__chiaroscuroCtxMenuPrevented = e.defaultPrevented;
+      });
+    }, { capture: true });
   })();
 `;
 

--- a/src/features/tab-context-menu/tab-context-menu.main.ts
+++ b/src/features/tab-context-menu/tab-context-menu.main.ts
@@ -1,0 +1,248 @@
+import type { CommandBus } from "../../bus/command-bus";
+import type { EventBus } from "../../bus/event-bus";
+import type { Platform } from "../../platform/types";
+import { defineFeature } from "../../shared/define-feature";
+import { logError } from "../../shared/log";
+import { TabScope } from "../../shared/tab-scope";
+import type { TabId } from "../../shared/types";
+import type { Bounds } from "../../shared/types";
+import type { SearchProvider } from "../command-palette/resolve-input";
+import { CONTEXT_MENU_SHOW, type ContextMenuCommands } from "../context-menu/context-menu.shared";
+import { SETTINGS_GET, type Settings, type SettingsCommands } from "../settings/settings.shared";
+import {
+  TABS_CLOSED,
+  TABS_CONTENT_BOUNDS_CHANGED,
+  TABS_CREATE,
+  TABS_CREATED,
+  TABS_LIST_CHANGED,
+  type TabsCommands,
+  type TabsEvents,
+} from "../tabs/tabs.shared";
+import {
+  TAB_CONTEXT_MENU_COPY_IMAGE,
+  TAB_CONTEXT_MENU_COPY_TEXT,
+  TAB_CONTEXT_MENU_DOWNLOAD_IMAGE,
+  TAB_CONTEXT_MENU_SEARCH_TEXT,
+  type TabContextMenuCommands,
+} from "./tab-context-menu.shared";
+
+type AllCommands = TabContextMenuCommands & ContextMenuCommands & SettingsCommands & TabsCommands;
+type AllEvents = TabsEvents;
+
+interface Deps {
+  commands: CommandBus<AllCommands>;
+  events: EventBus<AllEvents>;
+  platform: Platform;
+}
+
+// Content script to detect page-handled context menus.
+// Sets a flag that we check from the main process before showing our menu.
+const CONTEXT_MENU_DETECT_SCRIPT = `
+  (() => {
+    if (window.__chiaroscuroCtxMenuPatched) return;
+    window.__chiaroscuroCtxMenuPatched = true;
+    window.__chiaroscuroCtxMenuPrevented = false;
+    document.addEventListener('contextmenu', (e) => {
+      window.__chiaroscuroCtxMenuPrevented = e.defaultPrevented;
+    }, { capture: false });
+  })();
+`;
+
+interface ContextMenuParams {
+  x: number;
+  y: number;
+  linkURL: string;
+  srcURL: string;
+  mediaType: string;
+  selectionText: string;
+}
+
+function getSearchUrl(provider: SearchProvider, query: string): string {
+  return provider.urlTemplate.replace("{query}", encodeURIComponent(query));
+}
+
+export default defineFeature<Deps>({
+  register(deps) {
+    const { commands, events, platform } = deps;
+    const tabScope = new TabScope();
+
+    // Track tab content bounds for coordinate offset
+    let contentBounds: Bounds = { x: 0, y: 0, width: 0, height: 0 };
+    events.on(TABS_CONTENT_BOUNDS_CHANGED, (bounds) => {
+      contentBounds = bounds;
+    });
+
+    // ── Command handlers ───────────────────────────────────────────
+
+    commands.handle(TAB_CONTEXT_MENU_COPY_TEXT, async ({ text }) => {
+      platform.writeClipboard(text);
+    });
+
+    commands.handle(TAB_CONTEXT_MENU_COPY_IMAGE, async ({ tabId, x, y }) => {
+      platform.copyImageAt(tabId, x, y);
+    });
+
+    commands.handle(TAB_CONTEXT_MENU_DOWNLOAD_IMAGE, async ({ url, tabId }) => {
+      platform.downloadUrl(tabId, url);
+    });
+
+    commands.handle(TAB_CONTEXT_MENU_SEARCH_TEXT, async ({ text }) => {
+      const settings: Settings = await commands.send(SETTINGS_GET, undefined);
+      const providers = settings.searchProviders;
+      const defaultBang = settings.defaultSearchProviderId;
+      const provider = providers.find((p) => p.bang === defaultBang) ?? providers[0];
+      if (!provider) return;
+      const url = getSearchUrl(provider, text);
+      await commands.send(TABS_CREATE, { url });
+    });
+
+    // ── Attach context-menu listener to each tab ───────────────────
+
+    async function handleContextMenu(tabId: TabId, params: ContextMenuParams): Promise<void> {
+      // Check if the page handled the contextmenu event
+      try {
+        const prevented = await platform.executeJavaScript(
+          tabId,
+          "window.__chiaroscuroCtxMenuPrevented === true",
+        );
+        if (prevented) return;
+      } catch {
+        // If script execution fails (e.g., page not loaded), proceed with our menu
+      }
+
+      const items: { label: string; icon: string; action: () => void }[] = [];
+
+      // Selected text context
+      const selection = params.selectionText?.trim();
+      if (selection) {
+        items.push({
+          label: "Copy",
+          icon: "copy",
+          action: () => {
+            commands
+              .send(TAB_CONTEXT_MENU_COPY_TEXT, { text: selection })
+              .catch(logError("tab-context-menu", "copy text"));
+          },
+        });
+
+        // Get search provider name for label
+        let searchLabel = "Search";
+        try {
+          const settings: Settings = await commands.send(SETTINGS_GET, undefined);
+          const providers = settings.searchProviders;
+          const defaultBang = settings.defaultSearchProviderId;
+          const provider = providers.find((p) => p.bang === defaultBang) ?? providers[0];
+          if (provider) searchLabel = `Search with ${provider.name}`;
+        } catch {
+          // Fall back to generic label
+        }
+
+        items.push({
+          label: searchLabel,
+          icon: "magnifying-glass",
+          action: () => {
+            commands
+              .send(TAB_CONTEXT_MENU_SEARCH_TEXT, { text: selection })
+              .catch(logError("tab-context-menu", "search text"));
+          },
+        });
+      }
+
+      // Link context
+      if (params.linkURL) {
+        items.push({
+          label: "Copy link",
+          icon: "copy",
+          action: () => {
+            commands
+              .send(TAB_CONTEXT_MENU_COPY_TEXT, { text: params.linkURL })
+              .catch(logError("tab-context-menu", "copy link"));
+          },
+        });
+      }
+
+      // Image context
+      if (params.mediaType === "image" && params.srcURL) {
+        items.push({
+          label: "Copy image",
+          icon: "copy",
+          action: () => {
+            commands
+              .send(TAB_CONTEXT_MENU_COPY_IMAGE, { tabId, x: params.x, y: params.y })
+              .catch(logError("tab-context-menu", "copy image"));
+          },
+        });
+        items.push({
+          label: "Download image",
+          icon: "download",
+          action: () => {
+            commands
+              .send(TAB_CONTEXT_MENU_DOWNLOAD_IMAGE, { url: params.srcURL, tabId })
+              .catch(logError("tab-context-menu", "download image"));
+          },
+        });
+      }
+
+      // Nothing actionable — don't show menu
+      if (items.length === 0) return;
+
+      // Show context menu via overlay
+      // Offset by content bounds: params.x/y are relative to WebContentsView,
+      // but the overlay expects window-content-area coordinates.
+      const menuItems = items.map((it) => ({ label: it.label, icon: it.icon }));
+      const selectedIndex = await commands.send(CONTEXT_MENU_SHOW, {
+        items: menuItems,
+        x: params.x + contentBounds.x,
+        y: params.y + contentBounds.y,
+      });
+
+      if (selectedIndex >= 0 && selectedIndex < items.length) {
+        items[selectedIndex]?.action();
+      }
+    }
+
+    function attachContextMenuListener(tabId: TabId): void {
+      // Inject detection script when page loads
+      const cleanupLoad = platform.onTabEvent(tabId, "did-finish-load", () => {
+        platform.executeJavaScript(tabId, CONTEXT_MENU_DETECT_SCRIPT).catch(() => {}); // Ignore errors on restricted pages
+      });
+      tabScope.add(tabId, cleanupLoad);
+
+      // Also inject immediately in case page is already loaded
+      platform.executeJavaScript(tabId, CONTEXT_MENU_DETECT_SCRIPT).catch(() => {});
+
+      // Listen for context-menu events
+      const cleanupCtx = platform.onTabEvent(
+        tabId,
+        "context-menu",
+        (event: unknown, params: unknown) => {
+          // Prevent Chrome's default context menu — we show our own overlay
+          (event as { preventDefault?: () => void })?.preventDefault?.();
+          const p = params as ContextMenuParams;
+          handleContextMenu(tabId, p).catch(logError("tab-context-menu", "handle context menu"));
+        },
+      );
+      tabScope.add(tabId, cleanupCtx);
+    }
+
+    // Attach to newly created tabs
+    events.on(TABS_CREATED, ({ tab }) => {
+      if (tab.builtIn) return;
+      attachContextMenuListener(tab.id);
+    });
+
+    // Attach to restored tabs (start() emits TABS_LIST_CHANGED, not TABS_CREATED)
+    events.on(TABS_LIST_CHANGED, ({ tabs }) => {
+      for (const tab of tabs) {
+        if (tab.builtIn) continue;
+        if (tabScope.has(tab.id)) continue;
+        attachContextMenuListener(tab.id);
+      }
+    });
+
+    // Cleanup when tabs close
+    events.on(TABS_CLOSED, ({ tabId }) => {
+      tabScope.cleanup(tabId);
+    });
+  },
+});

--- a/src/features/tab-context-menu/tab-context-menu.main.ts
+++ b/src/features/tab-context-menu/tab-context-menu.main.ts
@@ -113,14 +113,15 @@ export default defineFeature<Deps>({
       const items: { label: string; icon: string; action: () => void }[] = [];
 
       // Selected text context
-      const selection = params.selectionText?.trim();
+      const rawSelection = params.selectionText ?? "";
+      const selection = rawSelection.trim();
       if (selection) {
         items.push({
           label: "Copy",
           icon: "copy",
           action: () => {
             commands
-              .send(TAB_CONTEXT_MENU_COPY_TEXT, { text: selection })
+              .send(TAB_CONTEXT_MENU_COPY_TEXT, { text: rawSelection })
               .catch(logError("tab-context-menu", "copy text"));
           },
         });

--- a/src/features/tab-context-menu/tab-context-menu.shared.ts
+++ b/src/features/tab-context-menu/tab-context-menu.shared.ts
@@ -1,0 +1,38 @@
+import type { TabId } from "../../shared/types";
+
+// ── Command names ────────────────────────────────────────────────
+export const TAB_CONTEXT_MENU_COPY_TEXT = "tab-context-menu:copy-text" as const;
+export const TAB_CONTEXT_MENU_COPY_IMAGE = "tab-context-menu:copy-image" as const;
+export const TAB_CONTEXT_MENU_DOWNLOAD_IMAGE = "tab-context-menu:download-image" as const;
+export const TAB_CONTEXT_MENU_SEARCH_TEXT = "tab-context-menu:search-text" as const;
+
+// ── Payload types ────────────────────────────────────────────────
+export interface CopyTextPayload {
+  text: string;
+}
+
+export interface CopyImagePayload {
+  tabId: TabId;
+  x: number;
+  y: number;
+}
+
+export interface DownloadImagePayload {
+  url: string;
+  tabId: TabId;
+}
+
+export interface SearchTextPayload {
+  text: string;
+}
+
+// ── Command registry ─────────────────────────────────────────────
+export type TabContextMenuCommands = {
+  [TAB_CONTEXT_MENU_COPY_TEXT]: { payload: CopyTextPayload; response: undefined };
+  [TAB_CONTEXT_MENU_COPY_IMAGE]: { payload: CopyImagePayload; response: undefined };
+  [TAB_CONTEXT_MENU_DOWNLOAD_IMAGE]: { payload: DownloadImagePayload; response: undefined };
+  [TAB_CONTEXT_MENU_SEARCH_TEXT]: { payload: SearchTextPayload; response: undefined };
+};
+
+// ── Event registry ───────────────────────────────────────────────
+export type TabContextMenuEvents = Record<string, never>;

--- a/src/features/tab-context-menu/tab-context-menu.test.ts
+++ b/src/features/tab-context-menu/tab-context-menu.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, it, vi } from "vitest";
+import { CommandBus } from "../../bus/command-bus";
+import { EventBus } from "../../bus/event-bus";
+import type { TabId } from "../../shared/types";
+import { createMockPlatform, makeTab } from "../../test-utils";
+import { CONTEXT_MENU_SHOW, type ContextMenuCommands } from "../context-menu/context-menu.shared";
+import { SETTINGS_GET, type Settings, type SettingsCommands } from "../settings/settings.shared";
+import {
+  TABS_CLOSED,
+  TABS_CREATE,
+  TABS_CREATED,
+  type TabsClosedEvent,
+  type TabsCommands,
+  type TabsCreatedEvent,
+} from "../tabs/tabs.shared";
+import feature from "./tab-context-menu.main";
+import {
+  TAB_CONTEXT_MENU_COPY_IMAGE,
+  TAB_CONTEXT_MENU_COPY_TEXT,
+  TAB_CONTEXT_MENU_DOWNLOAD_IMAGE,
+  TAB_CONTEXT_MENU_SEARCH_TEXT,
+  type TabContextMenuCommands,
+} from "./tab-context-menu.shared";
+
+const TAB_ID = "tab-1" as TabId;
+
+type AllCommands = TabContextMenuCommands & ContextMenuCommands & SettingsCommands & TabsCommands;
+type AllEvents = { [K in typeof TABS_CREATED]: TabsCreatedEvent } & {
+  [K in typeof TABS_CLOSED]: TabsClosedEvent;
+};
+
+const DEFAULT_SETTINGS: Settings = {
+  searchProviders: [
+    {
+      id: "builtin-google",
+      bang: "!g",
+      name: "Google",
+      urlTemplate: "https://www.google.com/search?q={query}",
+    },
+  ],
+  defaultSearchProviderId: "!g",
+  debugServer: { enabled: false, port: 9222 },
+};
+
+function setup() {
+  const commands = new CommandBus<AllCommands>();
+  const events = new EventBus<AllEvents>();
+
+  // Track onTabEvent callbacks by event type
+  const tabEventCallbacks = new Map<string, (...args: unknown[]) => void>();
+
+  const platform = createMockPlatform({
+    onTabEvent: vi.fn((_, event: string, cb: (...args: unknown[]) => void) => {
+      tabEventCallbacks.set(event, cb);
+      return () => {
+        tabEventCallbacks.delete(event);
+      };
+    }),
+    showContextMenu: vi.fn(async () => -1),
+    executeJavaScript: vi.fn(async () => false),
+  });
+
+  // Register settings handler
+  commands.handle(SETTINGS_GET, async () => DEFAULT_SETTINGS);
+  // Register tabs:create handler
+  commands.handle(TABS_CREATE, async () => TAB_ID);
+  // Register context menu show handler
+  commands.handle(CONTEXT_MENU_SHOW, async (payload) => {
+    return (platform.showContextMenu as ReturnType<typeof vi.fn>).mock.results.length > 0 ? -1 : -1;
+  });
+
+  feature.register({ commands, events, platform });
+
+  return { commands, events, platform, tabEventCallbacks };
+}
+
+function emitTabCreated(events: EventBus<AllEvents>, tabId = TAB_ID) {
+  const tab = makeTab({ id: tabId });
+  events.emit(TABS_CREATED, { tab });
+}
+
+async function triggerContextMenu(
+  tabEventCallbacks: Map<string, (...args: unknown[]) => void>,
+  params: Partial<{
+    x: number;
+    y: number;
+    linkURL: string;
+    srcURL: string;
+    mediaType: string;
+    selectionText: string;
+  }> = {},
+) {
+  const cb = tabEventCallbacks.get("context-menu");
+  if (!cb) throw new Error("No context-menu callback registered");
+  const fullParams = {
+    x: 100,
+    y: 200,
+    linkURL: "",
+    srcURL: "",
+    mediaType: "",
+    selectionText: "",
+    ...params,
+  };
+  cb({}, fullParams);
+  // Wait for async handleContextMenu to complete
+  await new Promise((r) => setTimeout(r, 10));
+}
+
+describe("tab-context-menu", () => {
+  describe("listener attachment", () => {
+    it("attaches context-menu and did-finish-load listeners on tab creation", () => {
+      const { events, platform } = setup();
+      emitTabCreated(events);
+
+      expect(platform.onTabEvent).toHaveBeenCalledWith(
+        TAB_ID,
+        "did-finish-load",
+        expect.any(Function),
+      );
+      expect(platform.onTabEvent).toHaveBeenCalledWith(
+        TAB_ID,
+        "context-menu",
+        expect.any(Function),
+      );
+    });
+
+    it("skips built-in tabs", () => {
+      const { events, platform } = setup();
+      const tab = makeTab({ id: "builtin-1" as TabId, builtIn: true });
+      events.emit(TABS_CREATED, { tab });
+
+      expect(platform.onTabEvent).not.toHaveBeenCalledWith(
+        "builtin-1",
+        "context-menu",
+        expect.any(Function),
+      );
+    });
+
+    it("cleans up listeners on tab close", () => {
+      const { events, tabEventCallbacks } = setup();
+      emitTabCreated(events);
+
+      expect(tabEventCallbacks.size).toBeGreaterThan(0);
+
+      events.emit(TABS_CLOSED, { tabId: TAB_ID, activatedTabId: null });
+      expect(tabEventCallbacks.size).toBe(0);
+    });
+  });
+
+  describe("context detection", () => {
+    it("does nothing when page prevented contextmenu", async () => {
+      const { events, platform, tabEventCallbacks } = setup();
+      (platform.executeJavaScript as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+      emitTabCreated(events);
+
+      await triggerContextMenu(tabEventCallbacks);
+
+      expect(platform.showContextMenu).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when no actionable context", async () => {
+      const { events, platform, tabEventCallbacks } = setup();
+      emitTabCreated(events);
+
+      await triggerContextMenu(tabEventCallbacks);
+
+      expect(platform.showContextMenu).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("selected text context", () => {
+    it("shows Copy and Search items for selected text", async () => {
+      const { events, commands, platform, tabEventCallbacks } = setup();
+      // Re-register context menu handler to return selected index
+      commands.unhandle?.(CONTEXT_MENU_SHOW);
+      commands.handle(CONTEXT_MENU_SHOW, async (payload) => {
+        expect(payload.items).toHaveLength(2);
+        expect(payload.items[0]).toEqual({ label: "Copy", icon: "copy" });
+        expect(payload.items[1]).toEqual({ label: "Search with Google", icon: "magnifying-glass" });
+        return -1; // dismiss
+      });
+
+      emitTabCreated(events);
+      await triggerContextMenu(tabEventCallbacks, { selectionText: "hello world" });
+    });
+
+    it("executes copy text when first item selected", async () => {
+      const { events, commands, platform, tabEventCallbacks } = setup();
+      commands.unhandle?.(CONTEXT_MENU_SHOW);
+      commands.handle(CONTEXT_MENU_SHOW, async () => 0); // select first item (Copy)
+
+      emitTabCreated(events);
+      await triggerContextMenu(tabEventCallbacks, { selectionText: "hello" });
+
+      // Wait for action callback
+      await new Promise((r) => setTimeout(r, 10));
+      expect(platform.writeClipboard).toHaveBeenCalledWith("hello");
+    });
+
+    it("executes search when second item selected", async () => {
+      const { events, commands, tabEventCallbacks } = setup();
+      const createSpy = vi.fn(async () => TAB_ID);
+      commands.unhandle?.(CONTEXT_MENU_SHOW);
+      commands.unhandle?.(TABS_CREATE);
+      commands.handle(CONTEXT_MENU_SHOW, async () => 1); // select Search
+      commands.handle(TABS_CREATE, createSpy);
+
+      emitTabCreated(events);
+      await triggerContextMenu(tabEventCallbacks, { selectionText: "test query" });
+
+      // Wait for action callbacks
+      await new Promise((r) => setTimeout(r, 10));
+      expect(createSpy).toHaveBeenCalledWith({
+        url: "https://www.google.com/search?q=test%20query",
+      });
+    });
+  });
+
+  describe("link context", () => {
+    it("shows Copy link item for links", async () => {
+      const { events, commands, platform, tabEventCallbacks } = setup();
+      commands.unhandle?.(CONTEXT_MENU_SHOW);
+      commands.handle(CONTEXT_MENU_SHOW, async (payload) => {
+        expect(payload.items).toHaveLength(1);
+        expect(payload.items[0]).toEqual({ label: "Copy link", icon: "copy" });
+        return -1;
+      });
+
+      emitTabCreated(events);
+      await triggerContextMenu(tabEventCallbacks, { linkURL: "https://example.com" });
+    });
+
+    it("copies link URL when selected", async () => {
+      const { events, commands, platform, tabEventCallbacks } = setup();
+      commands.unhandle?.(CONTEXT_MENU_SHOW);
+      commands.handle(CONTEXT_MENU_SHOW, async () => 0);
+
+      emitTabCreated(events);
+      await triggerContextMenu(tabEventCallbacks, { linkURL: "https://example.com/page" });
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(platform.writeClipboard).toHaveBeenCalledWith("https://example.com/page");
+    });
+  });
+
+  describe("image context", () => {
+    it("shows Copy image and Download image items", async () => {
+      const { events, commands, tabEventCallbacks } = setup();
+      commands.unhandle?.(CONTEXT_MENU_SHOW);
+      commands.handle(CONTEXT_MENU_SHOW, async (payload) => {
+        expect(payload.items).toHaveLength(2);
+        expect(payload.items[0]).toEqual({ label: "Copy image", icon: "copy" });
+        expect(payload.items[1]).toEqual({ label: "Download image", icon: "download" });
+        return -1;
+      });
+
+      emitTabCreated(events);
+      await triggerContextMenu(tabEventCallbacks, {
+        mediaType: "image",
+        srcURL: "https://example.com/img.png",
+      });
+    });
+
+    it("copies image when first item selected", async () => {
+      const { events, commands, platform, tabEventCallbacks } = setup();
+      commands.unhandle?.(CONTEXT_MENU_SHOW);
+      commands.handle(CONTEXT_MENU_SHOW, async () => 0);
+
+      emitTabCreated(events);
+      await triggerContextMenu(tabEventCallbacks, {
+        mediaType: "image",
+        srcURL: "https://example.com/img.png",
+        x: 150,
+        y: 250,
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(platform.copyImageAt).toHaveBeenCalledWith(TAB_ID, 150, 250);
+    });
+
+    it("downloads image when second item selected", async () => {
+      const { events, commands, platform, tabEventCallbacks } = setup();
+      commands.unhandle?.(CONTEXT_MENU_SHOW);
+      commands.handle(CONTEXT_MENU_SHOW, async () => 1);
+
+      emitTabCreated(events);
+      await triggerContextMenu(tabEventCallbacks, {
+        mediaType: "image",
+        srcURL: "https://example.com/img.png",
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(platform.downloadUrl).toHaveBeenCalledWith(TAB_ID, "https://example.com/img.png");
+    });
+  });
+
+  describe("combined contexts", () => {
+    it("shows items for selection + link + image", async () => {
+      const { events, commands, tabEventCallbacks } = setup();
+      commands.unhandle?.(CONTEXT_MENU_SHOW);
+      commands.handle(CONTEXT_MENU_SHOW, async (payload) => {
+        // Selection: Copy, Search | Link: Copy link | Image: Copy image, Download image
+        expect(payload.items).toHaveLength(5);
+        expect(payload.items.map((i: { label: string }) => i.label)).toEqual([
+          "Copy",
+          "Search with Google",
+          "Copy link",
+          "Copy image",
+          "Download image",
+        ]);
+        return -1;
+      });
+
+      emitTabCreated(events);
+      await triggerContextMenu(tabEventCallbacks, {
+        selectionText: "text",
+        linkURL: "https://example.com",
+        mediaType: "image",
+        srcURL: "https://example.com/img.png",
+      });
+    });
+  });
+
+  describe("command handlers", () => {
+    it("copy-text writes to clipboard", async () => {
+      const { commands, platform } = setup();
+      await commands.send(TAB_CONTEXT_MENU_COPY_TEXT, { text: "hello" });
+      expect(platform.writeClipboard).toHaveBeenCalledWith("hello");
+    });
+
+    it("copy-image delegates to platform", async () => {
+      const { commands, platform } = setup();
+      await commands.send(TAB_CONTEXT_MENU_COPY_IMAGE, {
+        tabId: TAB_ID,
+        x: 100,
+        y: 200,
+      });
+      expect(platform.copyImageAt).toHaveBeenCalledWith(TAB_ID, 100, 200);
+    });
+
+    it("download-image delegates to platform", async () => {
+      const { commands, platform } = setup();
+      await commands.send(TAB_CONTEXT_MENU_DOWNLOAD_IMAGE, {
+        url: "https://example.com/img.png",
+        tabId: TAB_ID,
+      });
+      expect(platform.downloadUrl).toHaveBeenCalledWith(TAB_ID, "https://example.com/img.png");
+    });
+
+    it("search-text opens new tab with search URL", async () => {
+      const { commands } = setup();
+      const createSpy = vi.fn(async () => TAB_ID);
+      commands.unhandle?.(TABS_CREATE);
+      commands.handle(TABS_CREATE, createSpy);
+
+      await commands.send(TAB_CONTEXT_MENU_SEARCH_TEXT, { text: "hello world" });
+
+      expect(createSpy).toHaveBeenCalledWith({
+        url: "https://www.google.com/search?q=hello%20world",
+      });
+    });
+  });
+});

--- a/src/features/tab-context-menu/tab-context-menu.test.ts
+++ b/src/features/tab-context-menu/tab-context-menu.test.ts
@@ -1,17 +1,20 @@
 import { describe, expect, it, vi } from "vitest";
 import { CommandBus } from "../../bus/command-bus";
 import { EventBus } from "../../bus/event-bus";
-import type { TabId } from "../../shared/types";
+import type { Bounds, TabId } from "../../shared/types";
 import { createMockPlatform, makeTab } from "../../test-utils";
 import { CONTEXT_MENU_SHOW, type ContextMenuCommands } from "../context-menu/context-menu.shared";
 import { SETTINGS_GET, type Settings, type SettingsCommands } from "../settings/settings.shared";
 import {
   TABS_CLOSED,
+  TABS_CONTENT_BOUNDS_CHANGED,
   TABS_CREATE,
   TABS_CREATED,
+  TABS_LIST_CHANGED,
   type TabsClosedEvent,
   type TabsCommands,
   type TabsCreatedEvent,
+  type TabsListChangedEvent,
 } from "../tabs/tabs.shared";
 import feature from "./tab-context-menu.main";
 import {
@@ -27,6 +30,8 @@ const TAB_ID = "tab-1" as TabId;
 type AllCommands = TabContextMenuCommands & ContextMenuCommands & SettingsCommands & TabsCommands;
 type AllEvents = { [K in typeof TABS_CREATED]: TabsCreatedEvent } & {
   [K in typeof TABS_CLOSED]: TabsClosedEvent;
+} & { [K in typeof TABS_CONTENT_BOUNDS_CHANGED]: Bounds } & {
+  [K in typeof TABS_LIST_CHANGED]: TabsListChangedEvent;
 };
 
 const DEFAULT_SETTINGS: Settings = {
@@ -66,7 +71,7 @@ function setup() {
   commands.handle(TABS_CREATE, async () => TAB_ID);
   // Register context menu show handler
   commands.handle(CONTEXT_MENU_SHOW, async (payload) => {
-    return (platform.showContextMenu as ReturnType<typeof vi.fn>).mock.results.length > 0 ? -1 : -1;
+    return platform.showContextMenu(payload);
   });
 
   feature.register({ commands, events, platform });
@@ -190,11 +195,11 @@ describe("tab-context-menu", () => {
       commands.handle(CONTEXT_MENU_SHOW, async () => 0); // select first item (Copy)
 
       emitTabCreated(events);
-      await triggerContextMenu(tabEventCallbacks, { selectionText: "hello" });
+      await triggerContextMenu(tabEventCallbacks, { selectionText: "  hello  " });
 
       // Wait for action callback
       await new Promise((r) => setTimeout(r, 10));
-      expect(platform.writeClipboard).toHaveBeenCalledWith("hello");
+      expect(platform.writeClipboard).toHaveBeenCalledWith("  hello  ");
     });
 
     it("executes search when second item selected", async () => {
@@ -318,6 +323,61 @@ describe("tab-context-menu", () => {
         mediaType: "image",
         srcURL: "https://example.com/img.png",
       });
+    });
+  });
+
+  describe("content bounds offset", () => {
+    it("offsets menu coordinates by content bounds", async () => {
+      const { events, commands, tabEventCallbacks } = setup();
+      commands.unhandle?.(CONTEXT_MENU_SHOW);
+      commands.handle(CONTEXT_MENU_SHOW, async (payload) => {
+        expect(payload.x).toBe(100 + 50);
+        expect(payload.y).toBe(200 + 80);
+        return -1;
+      });
+
+      events.emit(TABS_CONTENT_BOUNDS_CHANGED, { x: 50, y: 80, width: 800, height: 600 });
+      emitTabCreated(events);
+      await triggerContextMenu(tabEventCallbacks, { selectionText: "text" });
+    });
+  });
+
+  describe("restored tab attachment", () => {
+    it("attaches listeners to restored tabs via TABS_LIST_CHANGED", () => {
+      const { events, platform } = setup();
+      const restoredTab = makeTab({ id: "restored-1" as TabId });
+
+      events.emit(TABS_LIST_CHANGED, { tabs: [restoredTab] });
+
+      expect(platform.onTabEvent).toHaveBeenCalledWith(
+        "restored-1",
+        "context-menu",
+        expect.any(Function),
+      );
+    });
+
+    it("skips already-tracked tabs in TABS_LIST_CHANGED", () => {
+      const { events, platform } = setup();
+      emitTabCreated(events);
+
+      (platform.onTabEvent as ReturnType<typeof vi.fn>).mockClear();
+      events.emit(TABS_LIST_CHANGED, { tabs: [makeTab({ id: TAB_ID })] });
+
+      expect(platform.onTabEvent).not.toHaveBeenCalled();
+    });
+
+    it("skips built-in tabs in TABS_LIST_CHANGED", () => {
+      const { events, platform } = setup();
+
+      events.emit(TABS_LIST_CHANGED, {
+        tabs: [makeTab({ id: "builtin-1" as TabId, builtIn: true })],
+      });
+
+      expect(platform.onTabEvent).not.toHaveBeenCalledWith(
+        "builtin-1",
+        "context-menu",
+        expect.any(Function),
+      );
     });
   });
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -75,6 +75,11 @@ import sidebar from "../features/sidebar/sidebar.main";
 import type { SidebarCommands, SidebarEvents } from "../features/sidebar/sidebar.shared";
 import subTabs from "../features/sub-tabs/sub-tabs.main";
 import type { SubTabsCommands, SubTabsEvents } from "../features/sub-tabs/sub-tabs.shared";
+import tabContextMenu from "../features/tab-context-menu/tab-context-menu.main";
+import type {
+  TabContextMenuCommands,
+  TabContextMenuEvents,
+} from "../features/tab-context-menu/tab-context-menu.shared";
 import tabCustomization from "../features/tab-customization/tab-customization.main";
 import {
   getCustomization,
@@ -158,6 +163,7 @@ type AllCommands = MergeRegistries<
     LocalWebAppCommands,
     InstallerCommands,
     SubTabsCommands,
+    TabContextMenuCommands,
     DebugServerCommands,
     ExternalLinkCommands,
     PermissionsCommands,
@@ -187,6 +193,7 @@ type AllEvents = MergeRegistries<
     LocalWebAppEvents,
     InstallerEvents,
     SubTabsEvents,
+    TabContextMenuEvents,
     DebugServerEvents,
     ExternalLinkEvents,
     PermissionsEvents,
@@ -318,6 +325,7 @@ if (gotLock) {
     localWebApp.register(deps);
     installer.register(deps);
     subTabs.register(deps);
+    tabContextMenu.register(deps);
     externalLink.register(deps);
     permissions.register(deps);
 

--- a/src/platform/electron.ts
+++ b/src/platform/electron.ts
@@ -1593,6 +1593,26 @@ export class ElectronPlatform implements Platform {
     clipboard.writeText(text);
   }
 
+  // ── Tab content actions ──────────────────────────────────────
+
+  copyImageAt(tabId: TabId, x: number, y: number): void {
+    const view = this.views.get(tabId);
+    if (!view) return;
+    view.webContents.copyImageAt(x, y);
+  }
+
+  downloadUrl(tabId: TabId, url: string): void {
+    const view = this.views.get(tabId);
+    if (!view) return;
+    view.webContents.downloadURL(url);
+  }
+
+  async executeJavaScript(tabId: TabId, code: string): Promise<unknown> {
+    const view = this.views.get(tabId);
+    if (!view) return undefined;
+    return view.webContents.executeJavaScript(code);
+  }
+
   // ── Permissions ────────────────────────────────────────────────
 
   private findTabIdByWebContents(wc: Electron.WebContents): TabId | undefined {

--- a/src/platform/electron.ts
+++ b/src/platform/electron.ts
@@ -309,7 +309,8 @@ color:rgba(235,235,245,.5);transition:color 80ms ease-out;
 <script>
 const ICONS={
 'bookmark':'\\uf02e','thumbtack':'\\uf08d','thumbtack-slash':'\\ue68f',
-'xmark':'\\uf00d','sliders':'\\uf1de','arrow-rotate-left':'\\uf0e2','folder-plus':'\\uf65e'
+'xmark':'\\uf00d','sliders':'\\uf1de','arrow-rotate-left':'\\uf0e2','folder-plus':'\\uf65e',
+'copy':'\\uf0c5','download':'\\uf019','magnifying-glass':'\\uf002'
 };
 let _resolve=null;
 function _dismiss(){if(_resolve){_resolve(-1);_resolve=null}}

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -164,4 +164,12 @@ export interface Platform {
   openPath(filePath: string): Promise<void>;
   readClipboard(): string;
   writeClipboard(text: string): void;
+
+  // Tab content actions
+  /** Copy the image at (x, y) in the tab to the system clipboard. */
+  copyImageAt(tabId: TabId, x: number, y: number): void;
+  /** Trigger a download of the given URL in the tab's session. */
+  downloadUrl(tabId: TabId, url: string): void;
+  /** Execute JavaScript in the tab's webContents and return the result. */
+  executeJavaScript(tabId: TabId, code: string): Promise<unknown>;
 }

--- a/src/test-utils/mock-platform.ts
+++ b/src/test-utils/mock-platform.ts
@@ -77,6 +77,9 @@ export function createMockPlatform(overrides: Partial<Platform> = {}): Platform 
     openPath: vi.fn(),
     readClipboard: vi.fn(() => ""),
     writeClipboard: vi.fn(),
+    copyImageAt: vi.fn(),
+    downloadUrl: vi.fn(),
+    executeJavaScript: vi.fn(async () => undefined),
     ...overrides,
   } as Platform;
 }


### PR DESCRIPTION
Context-aware right-click menu for tab pages: copy/search selected text, copy link URLs, copy/download images. Defers to page's own context menu when present. Uses existing overlay component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tab context menu: right-click page content to copy text or links, copy or download images, or search selected text with your default search provider; respects sites that suppress custom context menus and uses consistent icons and dismissal interactions.

* **Documentation**
  * Added a feature spec detailing behaviors, UI, and command contracts.

* **Tests**
  * Added automated tests validating menu composition, actions, coordinate handling, and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->