### PR TITLE
Fix pinned tabs being ephemeral by bookmarking on pin

### DIFF
--- a/scripts/dev-win.sh
+++ b/scripts/dev-win.sh
@@ -21,7 +21,13 @@ cp package.json "$WIN_DIR/"
 # One-time: install electron on Windows side
 if [ ! -d "$WIN_DIR/node_modules/electron" ]; then
   echo "First run: installing Electron on Windows (one-time)..."
-  powershell.exe -NoProfile -Command "cd '$WIN_PATH'; npm install --ignore-scripts --save-dev electron; node node_modules/electron/install.js"
+  powershell.exe -NoProfile -Command "
+    Set-Location '$WIN_PATH'
+    npm install --ignore-scripts --save-dev electron
+    if (\$LASTEXITCODE -ne 0) { exit \$LASTEXITCODE }
+    node node_modules/electron/install.js
+    if (\$LASTEXITCODE -ne 0) { exit \$LASTEXITCODE }
+  "
 fi
 
 # Resolve electron.exe path

--- a/scripts/dev-win.sh
+++ b/scripts/dev-win.sh
@@ -21,7 +21,7 @@ cp package.json "$WIN_DIR/"
 # One-time: install electron on Windows side
 if [ ! -d "$WIN_DIR/node_modules/electron" ]; then
   echo "First run: installing Electron on Windows (one-time)..."
-  powershell.exe -NoProfile -Command "cd '$WIN_PATH'; npm install --save-dev electron"
+  powershell.exe -NoProfile -Command "cd '$WIN_PATH'; npm install --ignore-scripts --save-dev electron; node node_modules/electron/install.js"
 fi
 
 # Resolve electron.exe path

--- a/src/features/pinned-tabs/pinned-tabs.main.ts
+++ b/src/features/pinned-tabs/pinned-tabs.main.ts
@@ -13,6 +13,8 @@ import {
   TABS_CLOSE,
   TABS_CLOSED,
   TABS_CREATE,
+  TABS_GET,
+  TABS_TOGGLE_BOOKMARK,
   TABS_UPDATED,
 } from "../tabs/tabs.shared";
 import {
@@ -123,7 +125,13 @@ export default defineFeature<Deps>({
         pinnedTabs.delete(tabId);
         emitChanged();
       } else {
-        // Pin — get current tab data from platform
+        // Pin — ensure the tab is bookmarked before pinning so it can never be ephemeral
+        const tab = await commands.send(TABS_GET, { tabId });
+        if (!tab) return;
+        if (!tab.bookmarked) {
+          await commands.send(TABS_TOGGLE_BOOKMARK, { tabId });
+        }
+
         const url = platform.getTabUrl(tabId) ?? "";
         const title = platform.getTabTitle(tabId) ?? url;
         const pt: PinnedTab = {
@@ -163,6 +171,15 @@ export default defineFeature<Deps>({
 export async function start(deps: Deps): Promise<void> {
   const { pinnedTabs } = _state.get();
   await pinnedTabs.load({ sort: [{ field: "order", direction: "asc" }] });
+
+  // Ensure all pinned tabs are bookmarked (migration for pre-existing pinned-but-ephemeral tabs)
+  for (const pt of pinnedTabs.values()) {
+    const tab = await deps.commands.send(TABS_GET, { tabId: pt.id });
+    if (tab && !tab.bookmarked) {
+      await deps.commands.send(TABS_TOGGLE_BOOKMARK, { tabId: pt.id });
+    }
+  }
+
   if (pinnedTabs.size > 0) {
     deps.events.emit(PINNED_TABS_CHANGED, {
       pinnedTabs: pinnedTabs.values().sort((a, b) => a.order - b.order),

--- a/src/features/pinned-tabs/pinned-tabs.test.ts
+++ b/src/features/pinned-tabs/pinned-tabs.test.ts
@@ -57,6 +57,8 @@ function setup(overrides: { activeTabId?: TabId | null } = {}) {
     lastAccessedAt: 0,
     createdAt: 0,
     order: 0,
+    favicon: "",
+    folderId: null,
   }));
   commands.handle(TABS_TOGGLE_BOOKMARK, async () => {});
 
@@ -129,6 +131,8 @@ describe("pinned-tabs commands", () => {
         lastAccessedAt: 0,
         createdAt: 0,
         order: 0,
+        favicon: "",
+        folderId: null,
       }));
       const toggleBookmark = vi.fn();
       commands.unhandle(TABS_TOGGLE_BOOKMARK);
@@ -195,6 +199,7 @@ describe("pinned-tabs commands", () => {
           lastAccessedAt: 0,
           createdAt: 0,
           order: 0,
+          folderId: null,
         },
       });
 
@@ -249,8 +254,11 @@ describe("start()", () => {
       lastAccessedAt: 0,
       createdAt: 0,
       order: 0,
+      favicon: "",
+      folderId: null,
     }));
-    commands.handle(TABS_TOGGLE_BOOKMARK, async () => {});
+    const toggleBookmark = vi.fn();
+    commands.handle(TABS_TOGGLE_BOOKMARK, toggleBookmark);
 
     const deps = {
       commands,
@@ -275,5 +283,6 @@ describe("start()", () => {
         pinnedTabs: expect.arrayContaining([expect.objectContaining({ id: "tab-pinned" })]),
       }),
     );
+    expect(toggleBookmark).toHaveBeenCalledWith({ tabId: "tab-pinned" });
   });
 });

--- a/src/features/pinned-tabs/pinned-tabs.test.ts
+++ b/src/features/pinned-tabs/pinned-tabs.test.ts
@@ -9,6 +9,8 @@ import {
   TABS_CLOSE,
   TABS_CLOSED,
   TABS_CREATE,
+  TABS_GET,
+  TABS_TOGGLE_BOOKMARK,
   TABS_UPDATED,
 } from "../tabs/tabs.shared";
 import feature from "./pinned-tabs.main";
@@ -45,6 +47,18 @@ function setup(overrides: { activeTabId?: TabId | null } = {}) {
   commands.handle(TABS_ACTIVATE, async () => {});
   commands.handle(TABS_CLOSE, async () => {});
   commands.handle(TABS_CREATE, async () => "new-tab" as TabId);
+  commands.handle(TABS_GET, async ({ tabId }) => ({
+    id: tabId,
+    url: "https://example.com",
+    title: "Example",
+    workspaceId: "ws-1" as WorkspaceId,
+    bookmarked: false,
+    loading: false,
+    lastAccessedAt: 0,
+    createdAt: 0,
+    order: 0,
+  }));
+  commands.handle(TABS_TOGGLE_BOOKMARK, async () => {});
 
   const deps = {
     commands,
@@ -88,6 +102,41 @@ describe("pinned-tabs commands", () => {
       await commands.send(PINNED_TABS_TOGGLE_PIN, {}); // unpin
 
       expect(changed).toHaveBeenCalledWith({ pinnedTabs: [] });
+    });
+
+    it("bookmarks the tab when pinning an ephemeral tab", async () => {
+      const { commands } = setup();
+      const toggleBookmark = vi.fn();
+      // Re-register with spy
+      commands.unhandle(TABS_TOGGLE_BOOKMARK);
+      commands.handle(TABS_TOGGLE_BOOKMARK, toggleBookmark);
+
+      await commands.send(PINNED_TABS_TOGGLE_PIN, {});
+
+      expect(toggleBookmark).toHaveBeenCalledWith({ tabId: TAB_ID });
+    });
+
+    it("does not toggle bookmark when pinning an already-bookmarked tab", async () => {
+      const { commands } = setup();
+      commands.unhandle(TABS_GET);
+      commands.handle(TABS_GET, async ({ tabId }) => ({
+        id: tabId,
+        url: "https://example.com",
+        title: "Example",
+        workspaceId: "ws-1" as WorkspaceId,
+        bookmarked: true,
+        loading: false,
+        lastAccessedAt: 0,
+        createdAt: 0,
+        order: 0,
+      }));
+      const toggleBookmark = vi.fn();
+      commands.unhandle(TABS_TOGGLE_BOOKMARK);
+      commands.handle(TABS_TOGGLE_BOOKMARK, toggleBookmark);
+
+      await commands.send(PINNED_TABS_TOGGLE_PIN, {});
+
+      expect(toggleBookmark).not.toHaveBeenCalled();
     });
 
     it("no-ops when no active tab", async () => {
@@ -190,6 +239,18 @@ describe("start()", () => {
     commands.handle(TABS_ACTIVATE, async () => {});
     commands.handle(TABS_CLOSE, async () => {});
     commands.handle(TABS_CREATE, async () => "new-tab" as TabId);
+    commands.handle(TABS_GET, async ({ tabId }) => ({
+      id: tabId,
+      url: "https://example.com",
+      title: "Example",
+      workspaceId: "ws-1" as WorkspaceId,
+      bookmarked: false,
+      loading: false,
+      lastAccessedAt: 0,
+      createdAt: 0,
+      order: 0,
+    }));
+    commands.handle(TABS_TOGGLE_BOOKMARK, async () => {});
 
     const deps = {
       commands,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -132,6 +132,14 @@ process.on("unhandledRejection", (reason) => {
 const iconFile = process.platform === "win32" ? "icon.ico" : "icon.png";
 const iconPath = path.join(__dirname, "../../resources", iconFile);
 
+// ── Dev-mode isolation ───────────────────────────────────────────
+// Use a separate app identity so dev instances don't conflict with
+// the production single-instance lock or userData.
+const isDev = !!process.env.ELECTRON_RENDERER_URL;
+if (isDev) {
+  app.setName("Chiaroscuro Dev");
+}
+
 // ── Single-instance lock (must run before whenReady) ─────────────
 // Skip in test mode: parallel Playwright workers each launch their own
 // Electron instance, and the OS-level lock would reject all but the first.
@@ -212,7 +220,6 @@ let activeWindowId: WindowId | undefined;
 let activeTabId: TabId | undefined;
 let activeWorkspaceId: WorkspaceId | undefined;
 
-const isDev = !!process.env.ELECTRON_RENDERER_URL;
 if (isDev) app.setPath("userData", path.join(app.getPath("userData"), "..", "chiaroscuro-dev"));
 const platform = new ElectronPlatform(() => activeWindowId);
 const dataDir = process.env.DATA_DIR ?? path.join(app.getPath("userData"), "data");


### PR DESCRIPTION
## Summary
- Pinned tabs could have `bookmarked: false`, making them ephemeral — cleared by "Clear ephemeral", expired by TTL, and shown in the wrong sidebar section
- Pinning a tab now ensures it is bookmarked first, making it structurally impossible for a pinned tab to be ephemeral
- Migrates any existing pinned-but-ephemeral tabs on startup

## Test plan
- [x] New test: pinning an ephemeral tab triggers bookmark toggle
- [x] New test: pinning an already-bookmarked tab does not toggle bookmark
- [x] All 565 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pinned tabs now auto-bookmark when pinned and are auto-bookmarked on startup to ensure persistence and prevent ephemeral pinned tabs.

* **Tests**
  * Added tests validating bookmark side effects when pinning and during startup restoration.

* **Chores**
  * Windows dev install now skips lifecycle scripts and runs the Electron installer explicitly.
  * Added a distinct dev-mode app identity for developer runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->