### PR TITLE
Various small fixes and improvements

### DIFF
--- a/src/features/sidebar/TabSection.tsx
+++ b/src/features/sidebar/TabSection.tsx
@@ -158,6 +158,7 @@ export function TabSection({
               whiteSpace: "nowrap",
               letterSpacing: "0.02em",
             }}
+            tabIndex={-1}
             onClick={onClearEphemeral}
             data-tip="Clear ephemeral tabs"
           >

--- a/src/features/sidebar/sidebar.renderer.tsx
+++ b/src/features/sidebar/sidebar.renderer.tsx
@@ -330,7 +330,13 @@ export function SidebarPanel() {
               />
             )}
             <div className="flex-1 overflow-y-auto">
-              <div style={{ position: "relative", overflow: "hidden" }}>
+              <div
+                style={{
+                  position: "relative",
+                  overflow: "hidden",
+                  minHeight: wsTransition ? "100%" : undefined,
+                }}
+              >
                 {/* Exiting workspace tabs (slide out) */}
                 {wsTransition && prevTabs && (
                   <div

--- a/src/features/sidebar/sidebar.renderer.tsx
+++ b/src/features/sidebar/sidebar.renderer.tsx
@@ -308,13 +308,16 @@ export function SidebarPanel() {
             onContextMenu={handleSidebarContextMenu}
             onMouseDown={(e) => {
               // Prevent sidebar elements from receiving focus on click.
-              // Allow inputs (workspace editor) to still receive focus.
+              // Allow inputs (workspace editor) and draggable elements to keep defaults.
+              const target = e.target as HTMLElement;
               if (
-                !(e.target instanceof HTMLInputElement) &&
-                !(e.target instanceof HTMLTextAreaElement)
+                target instanceof HTMLInputElement ||
+                target instanceof HTMLTextAreaElement ||
+                target.closest("[draggable]")
               ) {
-                e.preventDefault();
+                return;
               }
+              e.preventDefault();
             }}
           >
             <div className="sr-only" aria-live="polite" aria-atomic="true">

--- a/src/features/sidebar/sidebar.renderer.tsx
+++ b/src/features/sidebar/sidebar.renderer.tsx
@@ -306,6 +306,16 @@ export function SidebarPanel() {
             onDragStart={() => setIsDragging(true)}
             onDragEnd={handleDragEnd}
             onContextMenu={handleSidebarContextMenu}
+            onMouseDown={(e) => {
+              // Prevent sidebar elements from receiving focus on click.
+              // Allow inputs (workspace editor) to still receive focus.
+              if (
+                !(e.target instanceof HTMLInputElement) &&
+                !(e.target instanceof HTMLTextAreaElement)
+              ) {
+                e.preventDefault();
+              }
+            }}
           >
             <div className="sr-only" aria-live="polite" aria-atomic="true">
               {announcement}

--- a/src/features/window-chrome/window-chrome.main.ts
+++ b/src/features/window-chrome/window-chrome.main.ts
@@ -78,12 +78,22 @@ interface Deps {
   platform: Platform;
   getActiveWindowId: () => WindowId | undefined;
   getActiveTabId: () => TabId | undefined;
+  /** Return the URL for a tab. Used for copy-address (falls back to tab store for built-in pages). */
+  getTabUrl: (tabId: TabId) => string | undefined;
   /** Optional handler for back navigation on special tabs (e.g. PDF). Returns true if handled. */
   handlePdfBack?: (tabId: TabId) => boolean;
 }
 
 export default defineFeature<Deps>({
-  register({ commands, events, platform, getActiveWindowId, getActiveTabId, handlePdfBack }) {
+  register({
+    commands,
+    events,
+    platform,
+    getActiveWindowId,
+    getActiveTabId,
+    getTabUrl,
+    handlePdfBack,
+  }) {
     commands.handle(WINDOW_MINIMIZE, async () => {
       const windowId = getActiveWindowId();
       if (windowId) await platform.minimizeWindow(windowId);
@@ -109,7 +119,7 @@ export default defineFeature<Deps>({
     commands.handle(WINDOW_COPY_ADDRESS, () => {
       const tabId = getActiveTabId();
       if (!tabId) return;
-      let url = platform.getTabUrl(tabId);
+      let url = getTabUrl(tabId);
       if (url?.startsWith("app:pdf-reader")) {
         const qIdx = url.indexOf("?");
         if (qIdx !== -1) {

--- a/src/features/window-chrome/window-chrome.main.ts
+++ b/src/features/window-chrome/window-chrome.main.ts
@@ -150,12 +150,18 @@ export default defineFeature<Deps>({
     });
   },
 
-  start({ events, platform, getActiveWindowId }) {
+  start({ commands, events, platform, getActiveWindowId }) {
     const windowId = getActiveWindowId();
     if (windowId) {
       events.emit(WINDOW_MAXIMIZED_CHANGED, {
         maximized: platform.isWindowMaximized(windowId),
       });
     }
+
+    const reload = () => commands.send(WINDOW_RELOAD, undefined);
+    platform.registerShortcut("F5", reload);
+    platform.registerLocalShortcut("F5", reload);
+    platform.registerShortcut("CommandOrControl+R", reload);
+    platform.registerLocalShortcut("CommandOrControl+R", reload);
   },
 });

--- a/src/features/window-chrome/window-chrome.test.ts
+++ b/src/features/window-chrome/window-chrome.test.ts
@@ -22,7 +22,10 @@ import {
 const WIN_ID = "win-1" as WindowId;
 const TAB_ID = "tab-1" as TabId;
 
-function setup(platformOverrides: Partial<Platform> = {}) {
+function setup(
+  platformOverrides: Partial<Platform> = {},
+  { getTabUrl }: { getTabUrl?: (tabId: TabId) => string | undefined } = {},
+) {
   const commands = new CommandBus<WindowChromeCommands>();
   const events = new EventBus<WindowChromeEvents>();
   const platform = createMockPlatform(platformOverrides);
@@ -32,6 +35,7 @@ function setup(platformOverrides: Partial<Platform> = {}) {
     platform,
     getActiveWindowId: () => WIN_ID as WindowId | undefined,
     getActiveTabId: () => TAB_ID as TabId | undefined,
+    getTabUrl: getTabUrl ?? (() => undefined),
   };
   feature.register(deps);
   return { commands, events, platform, deps };
@@ -77,19 +81,40 @@ describe("window-chrome commands", () => {
   });
 
   it("copy-address writes URL to clipboard", async () => {
-    const { commands, platform } = setup({
-      getTabUrl: vi.fn(() => "https://example.com"),
-    });
+    const { commands, platform } = setup({}, { getTabUrl: () => "https://example.com" });
     await commands.send(WINDOW_COPY_ADDRESS, undefined);
     expect(platform.writeClipboard).toHaveBeenCalledWith("https://example.com");
   });
 
   it("copy-address strips tracking params", async () => {
-    const { commands, platform } = setup({
-      getTabUrl: vi.fn(() => "https://example.com/page?q=test&utm_source=google&fbclid=abc"),
-    });
+    const { commands, platform } = setup(
+      {},
+      {
+        getTabUrl: () => "https://example.com/page?q=test&utm_source=google&fbclid=abc",
+      },
+    );
     await commands.send(WINDOW_COPY_ADDRESS, undefined);
     expect(platform.writeClipboard).toHaveBeenCalledWith("https://example.com/page?q=test");
+  });
+
+  it("copy-address extracts real URL from built-in PDF tab", async () => {
+    const pdfUrl = "https://example.com/doc.pdf";
+    const { commands, platform } = setup(
+      {},
+      { getTabUrl: () => `app:pdf-reader?url=${encodeURIComponent(pdfUrl)}` },
+    );
+    await commands.send(WINDOW_COPY_ADDRESS, undefined);
+    expect(platform.writeClipboard).toHaveBeenCalledWith(pdfUrl);
+  });
+
+  it("copy-address extracts real URL from local file PDF tab", async () => {
+    const fileUrl = "file:///home/user/doc.pdf";
+    const { commands, platform } = setup(
+      {},
+      { getTabUrl: () => `app:pdf-reader?url=${encodeURIComponent(fileUrl)}` },
+    );
+    await commands.send(WINDOW_COPY_ADDRESS, undefined);
+    expect(platform.writeClipboard).toHaveBeenCalledWith(fileUrl);
   });
 
   it("copy-address does nothing when no active tab", async () => {
@@ -102,6 +127,7 @@ describe("window-chrome commands", () => {
       platform,
       getActiveWindowId: () => WIN_ID,
       getActiveTabId: () => undefined,
+      getTabUrl: () => undefined,
     });
     await commands.send(WINDOW_COPY_ADDRESS, undefined);
     expect(platform.writeClipboard).not.toHaveBeenCalled();
@@ -117,6 +143,7 @@ describe("window-chrome commands", () => {
       platform,
       getActiveWindowId: () => undefined,
       getActiveTabId: () => undefined,
+      getTabUrl: () => undefined,
     });
     await commands.send(WINDOW_MINIMIZE, undefined);
     await commands.send(WINDOW_MAXIMIZE_RESTORE, undefined);

--- a/src/features/window-chrome/window-chrome.test.ts
+++ b/src/features/window-chrome/window-chrome.test.ts
@@ -184,6 +184,36 @@ describe("feature.start()", () => {
 
     expect(listener).toHaveBeenCalledWith({ maximized: true });
   });
+
+  it("registers F5 and Ctrl+R shortcuts for reload", () => {
+    const { platform, deps } = setup();
+    feature.start(deps);
+
+    expect(platform.registerShortcut).toHaveBeenCalledWith("F5", expect.any(Function));
+    expect(platform.registerLocalShortcut).toHaveBeenCalledWith("F5", expect.any(Function));
+    expect(platform.registerShortcut).toHaveBeenCalledWith(
+      "CommandOrControl+R",
+      expect.any(Function),
+    );
+    expect(platform.registerLocalShortcut).toHaveBeenCalledWith(
+      "CommandOrControl+R",
+      expect.any(Function),
+    );
+  });
+
+  it("F5 shortcut triggers reload of active tab", async () => {
+    const { platform, deps } = setup();
+    feature.start(deps);
+
+    const f5Call = vi
+      .mocked(platform.registerShortcut)
+      .mock.calls.find(([accel]) => accel === "F5");
+    f5Call?.[1]();
+    // Allow the command to propagate
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(platform.reload).toHaveBeenCalledWith(TAB_ID);
+  });
 });
 
 describe("stripTrackingParams", () => {

--- a/src/features/workspaces/workspaces.main.ts
+++ b/src/features/workspaces/workspaces.main.ts
@@ -111,6 +111,8 @@ export default defineFeature<Deps>({
       }
     });
 
+    let pendingHideAllTabsTimer: ReturnType<typeof setTimeout> | null = null;
+
     commands.handle(WORKSPACES_SWITCH, async (payload) => {
       const { workspaceId } = payload;
       const ws = workspaces.get(workspaceId);
@@ -118,6 +120,11 @@ export default defineFeature<Deps>({
 
       const previousWsId = getActiveWorkspaceId() ?? null;
       if (previousWsId === workspaceId) return;
+
+      if (pendingHideAllTabsTimer !== null) {
+        clearTimeout(pendingHideAllTabsTimer);
+        pendingHideAllTabsTimer = null;
+      }
 
       // Save current ws active tab
       if (previousWsId) {
@@ -142,7 +149,10 @@ export default defineFeature<Deps>({
         // Without this delay, hideAllTabs removes the WCV immediately, revealing
         // the white content-bg before React re-renders with the empty-state bg.
         events.emit(TABS_ACTIVATED, { tabId: null, previousTabId });
-        setTimeout(() => platform.hideAllTabs(), 50);
+        pendingHideAllTabsTimer = setTimeout(() => {
+          platform.hideAllTabs();
+          pendingHideAllTabsTimer = null;
+        }, 50);
       }
 
       events.emit(WORKSPACES_SWITCHED, {

--- a/src/features/workspaces/workspaces.main.ts
+++ b/src/features/workspaces/workspaces.main.ts
@@ -127,19 +127,22 @@ export default defineFeature<Deps>({
         }
       }
 
-      // Hide all tabs
-      platform.hideAllTabs();
-
       // Switch
       setActiveWorkspaceId(workspaceId);
 
       // Activate new ws's tab
       if (ws.activeTabId) {
+        // TABS_ACTIVATE hides the previous active tab and shows the new one
         await commands.send(TABS_ACTIVATE, { tabId: ws.activeTabId });
       } else {
         const previousTabId = getActiveTabId() ?? null;
         setActiveTabId(undefined);
+        // Emit deactivation first so the renderer updates the content area
+        // background to transparent before we hide the tab's WebContentsView.
+        // Without this delay, hideAllTabs removes the WCV immediately, revealing
+        // the white content-bg before React re-renders with the empty-state bg.
         events.emit(TABS_ACTIVATED, { tabId: null, previousTabId });
+        setTimeout(() => platform.hideAllTabs(), 50);
       }
 
       events.emit(WORKSPACES_SWITCHED, {

--- a/src/features/workspaces/workspaces.test.ts
+++ b/src/features/workspaces/workspaces.test.ts
@@ -118,6 +118,7 @@ describe("workspaces commands", () => {
 
   describe("WORKSPACES_SWITCH", () => {
     it("hides all tabs, emits SWITCHED", async () => {
+      vi.useFakeTimers();
       const { commands, events, platform, setActiveWsId } = setup();
       const ws1Id = await commands.send(WORKSPACES_CREATE, {
         name: "Work",
@@ -136,6 +137,9 @@ describe("workspaces commands", () => {
 
       await commands.send(WORKSPACES_SWITCH, { workspaceId: ws2Id });
 
+      // hideAllTabs is deferred for empty workspaces to let the renderer
+      // update the background before the WebContentsView is removed
+      vi.runAllTimers();
       expect(platform.hideAllTabs).toHaveBeenCalled();
       expect(switched).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -144,6 +148,7 @@ describe("workspaces commands", () => {
           workspaceName: "Personal",
         }),
       );
+      vi.useRealTimers();
     });
 
     it("no-ops when switching to same workspace", async () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -314,9 +314,12 @@ if (gotLock) {
       eventBus: events as unknown as EventBus<EventRegistry>,
     });
 
+    const getTabUrl = (tabId: TabId) => platform.getTabUrl(tabId) ?? getTab(tabId)?.url;
+
     appState.register(deps);
     windowChrome.register({
       ...deps,
+      getTabUrl,
       handlePdfBack: (tabId) => {
         const sourceUrl = getPdfSourceUrl(tabId);
         if (!sourceUrl) return false;
@@ -396,7 +399,7 @@ if (gotLock) {
     ipcMain.once("renderer:ready", async () => {
       appState.start?.(deps);
       await workspaces.start?.({ ...deps, getTabsForWorkspace });
-      windowChrome.start?.(deps);
+      windowChrome.start?.({ ...deps, getTabUrl });
       await installer.start?.(deps);
       await startTabs({
         ...deps,

--- a/src/renderer/src/components/ContentArea.tsx
+++ b/src/renderer/src/components/ContentArea.tsx
@@ -51,7 +51,7 @@ export function ContentArea() {
     const el = contentRef.current ?? mainRef.current;
     if (!el) return;
 
-    if (isBuiltIn || isCustomizing) {
+    if (!activeTabId || isBuiltIn || isCustomizing) {
       if (rafId.current !== null) {
         cancelAnimationFrame(rafId.current);
         rafId.current = null;
@@ -73,7 +73,7 @@ export function ContentArea() {
       observer.disconnect();
       window.removeEventListener("resize", reportBounds);
     };
-  }, [isBuiltIn, isCustomizing, terminalVisible]);
+  }, [activeTabId, isBuiltIn, isCustomizing, terminalVisible]);
 
   // Show terminal only for non-built-in, non-customizing tabs
   const showTerminal = terminalVisible && !isBuiltIn && !isCustomizing && !!activeTabId;


### PR DESCRIPTION
## Summary
- Fix white flash when switching to an empty workspace by deferring tab hiding until the renderer updates the background
- Fix workspace transition animation being skipped for empty workspaces
- Register F5 and Ctrl+R keyboard shortcuts for page reload
- Prevent sidebar elements from receiving keyboard focus
- Fix URL copy for PDF viewer and other built-in pages

## Test plan
- [ ] Switch to an empty workspace — no white flash visible
- [ ] Workspace slide animation plays when switching to/from empty workspaces
- [ ] F5 and Ctrl+R reload the active tab
- [ ] Clicking sidebar elements does not steal focus from the content area
- [ ] Copying URL from PDF viewer and built-in pages works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for reload: F5 and Ctrl/Cmd+R.

* **Improvements**
  * Prevented unintended keyboard focus on non-interactive sidebar elements and excluded a clear-tabs button from the tab order.
  * Improved layout and transition stability during workspace switches.
  * Avoided layout measurements when no tab is active to reduce visual glitches.

* **Tests**
  * Expanded tests for clipboard behavior, reload shortcuts, and deferred workspace hide behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->