### PR TITLE
Fix OAuth popups (Google login, etc.)

### DIFF
--- a/src/features/sub-tabs/sub-tabs.main.ts
+++ b/src/features/sub-tabs/sub-tabs.main.ts
@@ -279,15 +279,21 @@ export default defineFeature<Deps>({
         return true;
       }
 
-      // All other dispositions → sub-tab
-      const windowId = getActiveWindowId();
-      if (!windowId) return false;
+      // target="_blank" link clicks → sub-tab
+      if (disposition === "foreground-tab") {
+        const windowId = getActiveWindowId();
+        if (!windowId) return false;
 
-      const parentTabId = resolveParent(sourceTabId, stacks);
-      commands
-        .send(SUB_TABS_OPEN, { parentTabId, url })
-        .catch(logError("sub-tabs", "open sub-tab from window-open"));
-      return true;
+        const parentTabId = resolveParent(sourceTabId, stacks);
+        commands
+          .send(SUB_TABS_OPEN, { parentTabId, url })
+          .catch(logError("sub-tabs", "open sub-tab from window-open"));
+        return true;
+      }
+
+      // window.open() calls (OAuth popups, payment windows, etc.) →
+      // fall through to create a real BrowserWindow so window.opener works
+      return false;
     });
 
     // ── Command handlers ───────────────────────────────────────────

--- a/src/platform/electron.ts
+++ b/src/platform/electron.ts
@@ -406,13 +406,23 @@ export class ElectronPlatform implements Platform {
 
     view.webContents.setWindowOpenHandler(({ url, disposition }) => {
       if (isAllowedUrl(url)) {
-        // Let registered callback handle it (sub-tabs, etc.)
+        // Let registered callback handle it (sub-tabs for links, etc.)
         if (this.windowOpenCallback?.(url, tabId, disposition)) {
           return { action: "deny" as const };
         }
-        // Fallback: navigate the current tab
-        view.webContents.loadURL(url);
-      } else if (this.protocolRequestCallback) {
+        // Fallback: open as a real popup window so window.opener works
+        // (needed for OAuth flows, payment windows, etc.)
+        const parent = this.getWin();
+        return {
+          action: "allow" as const,
+          overrideBrowserWindowOptions: {
+            parent,
+            autoHideMenuBar: true,
+            webPreferences: { sandbox: true, contextIsolation: true },
+          },
+        };
+      }
+      if (this.protocolRequestCallback) {
         try {
           const parsed = new URL(url);
           if (
@@ -430,6 +440,27 @@ export class ElectronPlatform implements Platform {
         }
       }
       return { action: "deny" as const };
+    });
+
+    // Secure popup windows created by the above handler — guard navigation
+    // and prevent nested popups from escaping to disallowed URLs.
+    view.webContents.on("did-create-window", (popupWin) => {
+      const wc = popupWin.webContents;
+
+      wc.setWindowOpenHandler(({ url: childUrl }) => {
+        if (isAllowedUrl(childUrl)) {
+          wc.loadURL(childUrl);
+        }
+        return { action: "deny" as const };
+      });
+
+      wc.on("will-navigate", (event, navUrl) => {
+        if (!isAllowedUrl(navUrl)) {
+          event.preventDefault();
+        }
+      });
+
+      this.hookWebContents(wc);
     });
 
     view.webContents.on("will-navigate", (event, navUrl) => {
@@ -1444,6 +1475,11 @@ export class ElectronPlatform implements Platform {
   }
 
   private installPermissionHandlers(ses: Electron.Session): void {
+    // Present as standard Chrome so sites like Google don't block OAuth
+    // flows due to detecting "Electron" in the user-agent string.
+    const ua = ses.getUserAgent();
+    ses.setUserAgent(ua.replace(/ Electron\/\S+/g, "").replace(/ \S+\/\S+(?= Chrome\/)/g, ""));
+
     ses.setPermissionRequestHandler((wc, permission, callback, details) => {
       if (!this.permissionRequestHandler) {
         callback(false);

--- a/src/preload/tab.ts
+++ b/src/preload/tab.ts
@@ -2,6 +2,22 @@
 import { ipcRenderer, webFrame } from "electron";
 import { ZOOM_MAX, ZOOM_MIN, ZOOM_STEP } from "../features/zoom/zoom.shared";
 
+// Disable FedCM (Federated Credential Management) in the page context.
+// Electron doesn't implement the FedCM account-chooser UI for WebContentsView,
+// so the API hangs or fails silently. Removing it forces identity providers
+// (Google, etc.) to fall back to popup-based OAuth which we handle properly.
+webFrame.executeJavaScript(`
+  if (navigator.credentials) {
+    const origGet = navigator.credentials.get.bind(navigator.credentials);
+    navigator.credentials.get = function(options) {
+      if (options && options.identity) {
+        return Promise.reject(new DOMException("FedCM is not supported", "NotSupportedError"));
+      }
+      return origGet(options);
+    };
+  }
+`);
+
 // Capture Ctrl+wheel for zoom — the 'zoom-changed' webContents event
 // doesn't fire reliably in WebContentsView, so we handle zoom directly
 // via webFrame and notify the main process via IPC.


### PR DESCRIPTION
## Summary
- Disable FedCM in tab preload by rejecting `navigator.credentials.get({identity})` with `NotSupportedError` — Electron doesn't implement the FedCM UI for WebContentsView, so it hangs silently and identity providers never fall back to popup OAuth
- Allow `window.open()` calls to create real `BrowserWindow` popups (preserving `window.opener`) instead of denying them; sub-tabs now only intercept `target="_blank"` link clicks
- Strip `Electron/X.Y.Z` from user-agent so Google doesn't block OAuth from embedded browsers

## Test plan
- [ ] Open Pinterest, click "Continue with Google" → Google account chooser popup appears
- [ ] Complete Google login flow → authenticates successfully
- [ ] Ctrl+click / middle-click on a link → opens in background tab
- [ ] Click a `target="_blank"` link → opens as sub-tab overlay
- [ ] Verify other OAuth providers work (GitHub, Microsoft, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed window opening behavior to properly distinguish between foreground and background tab requests.
  * Strengthened popup window security with enhanced sandboxing and context isolation.

* **Security**
  * Added protection against unsupported identity-based credential requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->