### PR TITLE
Add picture-in-picture feature using native browser PiP API

### DIFF
--- a/design-system/src/pages/components/pip-player.mdx
+++ b/design-system/src/pages/components/pip-player.mdx
@@ -1,0 +1,238 @@
+---
+title: PiP Player
+---
+
+import { ComponentPreview } from "../../components/ComponentPreview"
+
+# PiP Player
+
+Always-on-top floating video player that appears when switching away from a tab with a playing video. A separate desktop window — independent of the browser — positioned at the bottom-right corner of the screen.
+
+<ComponentPreview label="PiP Player (hover state)">
+  <div style={{
+    position: "relative",
+    width: 400,
+    height: 225,
+    borderRadius: 12,
+    background: "oklch(0.15 0 0)",
+    overflow: "hidden",
+    boxShadow: "0 8px 32px oklch(0 0 0 / 0.35), 0 2px 8px oklch(0 0 0 / 0.18)",
+  }}>
+    {/* Simulated video content */}
+    <div style={{
+      position: "absolute",
+      inset: 0,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      color: "oklch(1 0 0 / 0.15)",
+      fontSize: "3rem",
+    }}>
+      <i className="fa-solid fa-film" />
+    </div>
+    {/* Hover scrim */}
+    <div style={{
+      position: "absolute",
+      inset: 0,
+      borderRadius: 12,
+      background: "oklch(0 0 0 / 0.45)",
+    }} />
+    {/* Return button */}
+    <button type="button" style={{
+      position: "absolute",
+      top: 8,
+      left: 8,
+      width: 28,
+      height: 28,
+      borderRadius: "50%",
+      border: "none",
+      background: "oklch(1 0 0 / 0.9)",
+      color: "oklch(0.25 0 0)",
+      fontSize: "0.625rem",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      boxShadow: "0 2px 8px oklch(0 0 0 / 0.25)",
+      cursor: "pointer",
+    }}>
+      <i className="fa-solid fa-up-right-from-square" />
+    </button>
+    {/* Play/Pause button */}
+    <button type="button" style={{
+      position: "absolute",
+      top: "50%",
+      left: "50%",
+      transform: "translate(-50%, -50%)",
+      width: 48,
+      height: 48,
+      borderRadius: "50%",
+      border: "none",
+      background: "white",
+      color: "oklch(0.15 0 0)",
+      fontSize: "1.125rem",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      boxShadow: "0 4px 16px oklch(0 0 0 / 0.3)",
+      cursor: "pointer",
+    }}>
+      <i className="fa-solid fa-pause" />
+    </button>
+    {/* Close button */}
+    <button type="button" style={{
+      position: "absolute",
+      top: 8,
+      right: 8,
+      width: 28,
+      height: 28,
+      borderRadius: "50%",
+      border: "none",
+      background: "oklch(1 0 0 / 0.9)",
+      color: "oklch(0.25 0 0)",
+      fontSize: "0.625rem",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      boxShadow: "0 2px 8px oklch(0 0 0 / 0.25)",
+      cursor: "pointer",
+    }}>
+      <i className="fa-solid fa-xmark" />
+    </button>
+  </div>
+</ComponentPreview>
+
+## Anatomy
+
+1. **Content window** — frameless, transparent BrowserWindow containing the tab's WebContentsView
+2. **Overlay window** — transparent child BrowserWindow on top with hover controls
+3. **Scrim** — semi-transparent dark overlay, visible on hover
+4. **Play/Pause button** — centered, large circular button
+5. **Return button** — top-left corner, small circular button
+6. **Close button** — top-right corner, small circular button
+
+---
+
+## Visual Specs
+
+### Content Window
+
+| Property | Token/Value |
+|----------|-------------|
+| Size | `400px` × `225px` (16:9) |
+| Position | Bottom-right of primary display, `24px` margin |
+| Border radius | `12px` (on the WebContentsView) |
+| Background | Transparent (video fills entire area) |
+| Always on top | `true` |
+
+### Overlay / Scrim
+
+| Property | Token/Value |
+|----------|-------------|
+| Background | `oklch(0 0 0 / 0.45)` |
+| Border radius | `12px` |
+| Shadow | `0 8px 32px oklch(0 0 0 / 0.35), 0 2px 8px oklch(0 0 0 / 0.18)` |
+
+### Play/Pause Button
+
+| Property | Token/Value |
+|----------|-------------|
+| Size | `48px` × `48px` |
+| Border radius | `50%` (fully round) |
+| Background | `white` |
+| Icon color | `oklch(0.15 0 0)` |
+| Icon size | `1.125rem` |
+| Box shadow | `0 4px 16px oklch(0 0 0 / 0.3)` |
+| Position | Centered in overlay |
+
+### Corner Buttons (Return, Close)
+
+| Property | Token/Value |
+|----------|-------------|
+| Size | `28px` × `28px` |
+| Border radius | `50%` (fully round) |
+| Background | `oklch(1 0 0 / 0.9)` |
+| Icon color | `oklch(0.25 0 0)` |
+| Icon size | `0.625rem` |
+| Box shadow | `0 2px 8px oklch(0 0 0 / 0.25)` |
+| Return position | `top: 8px; left: 8px` |
+| Close position | `top: 8px; right: 8px` |
+
+---
+
+## States
+
+### Overlay States
+
+| State | Effect |
+|-------|--------|
+| Default (no hover) | Scrim and buttons hidden (opacity 0) |
+| Hover | Scrim and buttons fade in (opacity 1) |
+
+### Button States
+
+| State | Effect |
+|-------|--------|
+| Default | As specified above |
+| Hover | `scale(1.1)` |
+| Active/Pressed | `scale(0.95)` |
+
+---
+
+## Behavior
+
+- **Trigger**: Automatically activates when switching away from a tab playing an HTML5 `<video>` element.
+- **Video continuity**: The WebContentsView is moved (not recreated), so video playback is uninterrupted.
+- **Single instance**: Only one PiP player at a time. Activating PiP for a new tab replaces the previous.
+- **Auto-dismiss**: PiP dismisses when the source tab is reactivated.
+- **Close**: Pauses the video and hides the PiP window.
+- **Return to tab**: Activates the source tab (PiP auto-dismisses).
+- **Tab close**: If the source tab is closed, PiP disappears immediately.
+- **Play/Pause icon**: Toggles between `fa-pause` and `fa-play` based on current state.
+
+---
+
+## Animation & Motion
+
+| Transition | Duration | Easing |
+|-----------|----------|--------|
+| Scrim opacity | `200ms` | `ease-out` |
+| Button opacity | `200ms` | `ease-out` |
+| Button scale (hover) | `150ms` | `ease-out` |
+
+`prefers-reduced-motion`: All transitions should be instant.
+
+---
+
+## Keyboard & Focus
+
+The PiP window is `focusable: false` — it never steals keyboard focus from the current application. All interactions are mouse-only.
+
+---
+
+## Accessibility
+
+- Play/Pause button: `aria-label="Toggle play/pause"`.
+- Return button: `aria-label="Return to tab"`.
+- Close button: `aria-label="Close"`.
+- Play/Pause size 48px exceeds `var(--click-target-min)` (24px).
+- Corner buttons at 28px exceed minimum click target.
+- Window is `skipTaskbar: true` and `focusable: false` — behaves as a non-intrusive overlay.
+
+---
+
+## Layout & Composition
+
+| Property | Value |
+|----------|-------|
+| Parent | None (independent desktop window) |
+| Position | Screen-absolute, bottom-right of primary display |
+| Z-index | Always-on-top (OS level) |
+| Architecture | Two BrowserWindows: content (holds WCV) + overlay (controls) |
+
+---
+
+## Related
+
+- [Tabs](/components/tabs) — tab activation triggers PiP check
+- [Web Content Host](/components/web-content-host) — WCV management
+- [Sub-Tab Overlay](/components/sub-tab-overlay) — similar two-window pattern

--- a/design-system/src/routes.ts
+++ b/design-system/src/routes.ts
@@ -198,4 +198,10 @@ export const routes: Route[] = [
     group: "Components",
     component: lazy(() => import("./pages/components/pdf-viewer.mdx")),
   },
+  {
+    path: "/components/pip-player",
+    title: "PiP Player",
+    group: "Components",
+    component: lazy(() => import("./pages/components/pip-player.mdx")),
+  },
 ];

--- a/docs/features/PictureInPictureFeature.specs.md
+++ b/docs/features/PictureInPictureFeature.specs.md
@@ -1,0 +1,92 @@
+# Specification for Picture-in-Picture Feature
+
+## Overview
+
+Automatically continues video playback in a small floating always-on-top window when the user switches away from a tab that is playing a video. The player appears in the lower-right corner of the desktop, independent of the browser window, providing uninterrupted video watching while using any application.
+
+## Terminology
+
+- **PiP**: Picture-in-Picture — a small always-on-top desktop window that continues playing a video from a background tab.
+- **Source tab**: The tab whose video is displayed in the PiP player.
+- **PiP window**: The frameless, always-on-top BrowserWindow in the bottom-right corner of the screen.
+
+## Requirements
+
+- When the user switches away from a tab that has a playing `<video>` element, the tab's WebContentsView is moved from the main window into a separate PiP BrowserWindow.
+- The PiP window is always-on-top over all desktop windows, frameless, and positioned at the bottom-right corner of the primary display.
+- The PiP window is approximately 400×225px (16:9 aspect ratio) with rounded corners and an elevated shadow.
+- Video playback continues seamlessly — no interruption or reload.
+- When the source tab is reactivated, the PiP window closes and the WCV moves back to the main window.
+- Only one PiP player can be active at a time.
+- Hovering over the PiP window reveals overlay controls with a fade-in animation:
+  - A **play/pause** button centered in the player.
+  - A **return-to-tab** button in the top-left corner.
+  - A **close (X)** button in the top-right corner.
+- Clicking the close button pauses the video and dismisses the PiP window.
+- Clicking the return-to-tab button activates the source tab (dismissing PiP).
+- If the source tab is closed, the PiP window closes immediately.
+- Video detection uses `executeJavaScript` to check for a `<video>` element that is currently playing (`!paused && readyState >= 2`).
+
+## Workflows
+
+### Automatic PiP Activation
+
+1. User is watching a video on a tab (e.g., YouTube).
+2. User switches to another tab (clicks sidebar, Ctrl+Tab, etc.).
+3. Main process detects a playing video in the previous tab via `executeJavaScript`.
+4. The previous tab's WCV is moved from the main window into the PiP BrowserWindow.
+5. The PiP window appears at the bottom-right corner of the screen, always-on-top.
+6. The PiP window's HTML overlay is invisible until hovered.
+
+### Hovering Over PiP
+
+1. User moves mouse over the PiP window.
+2. A semi-transparent dark scrim fades in over the video.
+3. Play/pause, return-to-tab, and close buttons fade in.
+4. User moves mouse away — controls fade out.
+
+### Closing PiP
+
+1. User clicks the X button on the PiP overlay.
+2. Main process pauses the video via `executeJavaScript`.
+3. The WCV is moved back to the main window and hidden.
+4. The PiP window is hidden.
+
+### Returning to Source Tab
+
+1. User clicks the return-to-tab button.
+2. The source tab is activated via `tabs:activate`.
+3. PiP is dismissed as part of the normal tab activation flow (WCV moved back, PiP window hidden).
+
+## Interactions
+
+### Mouse interactions
+
+- **Hover on PiP window**: Reveals overlay controls with fade animation.
+- **Click play/pause**: Toggles video playback.
+- **Click close (X)**: Pauses video and dismisses PiP.
+- **Click return-to-tab**: Activates the source tab.
+
+### Cross-feature interactions
+
+- **Tabs**: Listens to `tabs:activated` to trigger PiP on tab switch. Listens to `tabs:closed` to dismiss PiP if source tab is closed.
+- **Platform**: New platform methods for PiP window lifecycle (create, show, hide, attach/detach WCV).
+
+## Commands & Events
+
+### Commands
+
+- `pip:close` — Close the PiP player and pause the video. Payload: `undefined`.
+- `pip:toggle-play` — Toggle play/pause on the PiP video. Payload: `undefined`.
+- `pip:return-to-tab` — Activate the source tab, dismissing PiP. Payload: `undefined`.
+
+### Events
+
+- `pip:activated` — PiP entered for a tab. Payload: `{ tabId: TabId }`.
+- `pip:deactivated` — PiP dismissed. Payload: `undefined`.
+- `pip:play-state-changed` — Video play state changed. Payload: `{ playing: boolean }`.
+
+## Unresolved Issues
+
+- Cross-origin iframes: Video detection via `executeJavaScript` cannot reach into cross-origin iframes. Some embedded players (not YouTube's main page, but embedded YouTube on other sites) may not be detectable. This is acceptable as a known limitation.
+- DRM-protected content: Some DRM video players may not expose standard `<video>` elements. This is acceptable.

--- a/src/features/pip/pip.feature.ts
+++ b/src/features/pip/pip.feature.ts
@@ -1,0 +1,7 @@
+import { registerFeature } from "../../renderer/src/Shell";
+import { subscribeToEvents } from "./pip.store";
+
+registerFeature({
+  name: "pip",
+  subscribeToEvents,
+});

--- a/src/features/pip/pip.main.ts
+++ b/src/features/pip/pip.main.ts
@@ -1,0 +1,177 @@
+import type { CommandBus } from "../../bus/command-bus";
+import type { EventBus } from "../../bus/event-bus";
+import type { Platform } from "../../platform/types";
+import { defineFeature } from "../../shared/define-feature";
+import type { TabId } from "../../shared/types";
+import type {
+  TABS_ACTIVATED,
+  TABS_CLOSED,
+  TabsActivatedEvent,
+  TabsClosedEvent,
+} from "../tabs/tabs.shared";
+import {
+  PIP_ACTIVATED,
+  PIP_CLOSE,
+  PIP_DEACTIVATED,
+  PIP_PLAY_STATE_CHANGED,
+  PIP_RETURN_TO_TAB,
+  PIP_TOGGLE_PLAY,
+  type PipCommands,
+  type PipEvents,
+} from "./pip.shared";
+
+type AllCommands = PipCommands & {
+  "tabs:activate": { payload: { tabId: TabId }; response: undefined };
+};
+type AllEvents = PipEvents & {
+  [K in typeof TABS_ACTIVATED]: TabsActivatedEvent;
+} & {
+  [K in typeof TABS_CLOSED]: TabsClosedEvent;
+};
+
+/** JS: detect a playing <video> element. */
+const DETECT_VIDEO_JS = `(function() {
+  var videos = document.querySelectorAll('video');
+  for (var i = 0; i < videos.length; i++) {
+    var v = videos[i];
+    if (!v.paused && v.readyState >= 2 && v.duration > 0) return true;
+  }
+  return false;
+})()`;
+
+/** JS: enter native PiP via the browser's built-in API. */
+const ENTER_PIP_JS = `(function() {
+  var videos = document.querySelectorAll('video');
+  for (var i = 0; i < videos.length; i++) {
+    var v = videos[i];
+    if (!v.paused && v.readyState >= 2 && v.duration > 0) {
+      v.requestPictureInPicture().catch(function() {});
+      return true;
+    }
+  }
+  return false;
+})()`;
+
+/** JS: exit native PiP. */
+const EXIT_PIP_JS = `(function() {
+  if (document.pictureInPictureElement) {
+    document.exitPictureInPicture().catch(function() {});
+    return true;
+  }
+  return false;
+})()`;
+
+/** JS: pause the PiP video. */
+const PAUSE_VIDEO_JS = `(function() {
+  var v = document.pictureInPictureElement;
+  if (v && !v.paused) { v.pause(); return true; }
+  return false;
+})()`;
+
+/** JS: play the PiP video. */
+const PLAY_VIDEO_JS = `(function() {
+  var v = document.pictureInPictureElement;
+  if (v && v.paused) { v.play(); return true; }
+  return false;
+})()`;
+
+interface Deps {
+  commands: CommandBus<AllCommands>;
+  events: EventBus<AllEvents>;
+  platform: Platform;
+  getActiveTabId: () => TabId | undefined;
+}
+
+export default defineFeature<Deps>({
+  register(deps) {
+    const { commands, events, platform } = deps;
+
+    let pipTabId: TabId | undefined;
+    let pipPlaying = true;
+
+    function dismissPip(): void {
+      if (!pipTabId) return;
+      const tabId = pipTabId;
+      pipTabId = undefined;
+      // Exit native PiP
+      platform.executeJavaScript(tabId, EXIT_PIP_JS).catch(() => {});
+      events.emit(PIP_DEACTIVATED, undefined);
+    }
+
+    // ── Command handlers ────────────────────────────────────────
+
+    commands.handle(PIP_CLOSE, async () => {
+      if (!pipTabId) return;
+      // Pause the video and exit PiP
+      try {
+        await platform.executeJavaScript(pipTabId, PAUSE_VIDEO_JS);
+      } catch {
+        // tab may be destroyed
+      }
+      dismissPip();
+    });
+
+    commands.handle(PIP_TOGGLE_PLAY, async () => {
+      if (!pipTabId) return;
+      try {
+        if (pipPlaying) {
+          await platform.executeJavaScript(pipTabId, PAUSE_VIDEO_JS);
+          pipPlaying = false;
+        } else {
+          await platform.executeJavaScript(pipTabId, PLAY_VIDEO_JS);
+          pipPlaying = true;
+        }
+        events.emit(PIP_PLAY_STATE_CHANGED, { playing: pipPlaying });
+      } catch {
+        // tab may be destroyed
+      }
+    });
+
+    commands.handle(PIP_RETURN_TO_TAB, async () => {
+      if (!pipTabId) return;
+      const tabId = pipTabId;
+      dismissPip();
+      await commands.send("tabs:activate", { tabId });
+    });
+
+    // ── Event listeners ─────────────────────────────────────────
+
+    events.on("tabs:activated", (payload: TabsActivatedEvent) => {
+      const { previousTabId, tabId } = payload;
+
+      // If the activated tab is the PiP source, dismiss PiP
+      if (pipTabId && tabId === pipTabId) {
+        dismissPip();
+        return;
+      }
+
+      // Check if previous tab has a playing video
+      if (!previousTabId) return;
+      if (pipTabId === previousTabId) return;
+
+      platform
+        .executeJavaScript(previousTabId, DETECT_VIDEO_JS)
+        .then((hasVideo) => {
+          if (!hasVideo) return;
+          if (pipTabId === previousTabId) return;
+          if (deps.getActiveTabId() === previousTabId) return;
+
+          // Enter native PiP via the browser's built-in API (userGesture=true to bypass activation requirement)
+          return platform.executeJavaScript(previousTabId, ENTER_PIP_JS, true).then((entered) => {
+            if (!entered) return;
+            pipTabId = previousTabId;
+            pipPlaying = true;
+            events.emit(PIP_ACTIVATED, { tabId: previousTabId });
+          });
+        })
+        .catch(() => {});
+    });
+
+    events.on("tabs:closed", (payload: TabsClosedEvent) => {
+      if (pipTabId && payload.tabId === pipTabId) {
+        pipTabId = undefined;
+        events.emit(PIP_DEACTIVATED, undefined);
+      }
+    });
+  },
+});

--- a/src/features/pip/pip.shared.ts
+++ b/src/features/pip/pip.shared.ts
@@ -1,0 +1,34 @@
+import type { TabId } from "../../shared/types";
+
+// ── Command names ────────────────────────────────────────────────
+export const PIP_CLOSE = "pip:close" as const;
+export const PIP_TOGGLE_PLAY = "pip:toggle-play" as const;
+export const PIP_RETURN_TO_TAB = "pip:return-to-tab" as const;
+
+// ── Event names ──────────────────────────────────────────────────
+export const PIP_ACTIVATED = "pip:activated" as const;
+export const PIP_DEACTIVATED = "pip:deactivated" as const;
+export const PIP_PLAY_STATE_CHANGED = "pip:play-state-changed" as const;
+
+// ── Payload types ────────────────────────────────────────────────
+export interface PipActivatedEvent {
+  tabId: TabId;
+}
+
+export interface PipPlayStateChangedEvent {
+  playing: boolean;
+}
+
+// ── Command registry ─────────────────────────────────────────────
+export type PipCommands = {
+  [PIP_CLOSE]: { payload: undefined; response: undefined };
+  [PIP_TOGGLE_PLAY]: { payload: undefined; response: undefined };
+  [PIP_RETURN_TO_TAB]: { payload: undefined; response: undefined };
+};
+
+// ── Event registry ───────────────────────────────────────────────
+export type PipEvents = {
+  [PIP_ACTIVATED]: PipActivatedEvent;
+  [PIP_DEACTIVATED]: undefined;
+  [PIP_PLAY_STATE_CHANGED]: PipPlayStateChangedEvent;
+};

--- a/src/features/pip/pip.store.ts
+++ b/src/features/pip/pip.store.ts
@@ -1,0 +1,50 @@
+import { create } from "zustand";
+import { typedOnEvent } from "../../shared/typed-on-event";
+import type { TabId } from "../../shared/types";
+import {
+  PIP_ACTIVATED,
+  PIP_DEACTIVATED,
+  PIP_PLAY_STATE_CHANGED,
+  type PipEvents,
+} from "./pip.shared";
+
+interface PipState {
+  active: boolean;
+  tabId: TabId | null;
+  playing: boolean;
+}
+
+export const usePipStore = create<PipState>()(() => ({
+  active: false,
+  tabId: null,
+  playing: true,
+}));
+
+export function subscribeToEvents(
+  onEvent: (name: string, callback: (payload: unknown) => void) => () => void,
+): () => void {
+  const on = typedOnEvent<PipEvents>(onEvent);
+  const unsubs: (() => void)[] = [];
+
+  unsubs.push(
+    on(PIP_ACTIVATED, ({ tabId }) => {
+      usePipStore.setState({ active: true, tabId, playing: true });
+    }),
+  );
+
+  unsubs.push(
+    on(PIP_DEACTIVATED, () => {
+      usePipStore.setState({ active: false, tabId: null, playing: true });
+    }),
+  );
+
+  unsubs.push(
+    on(PIP_PLAY_STATE_CHANGED, ({ playing }) => {
+      usePipStore.setState({ playing });
+    }),
+  );
+
+  return () => {
+    for (const unsub of unsubs) unsub();
+  };
+}

--- a/src/features/pip/pip.test.ts
+++ b/src/features/pip/pip.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi } from "vitest";
+import { CommandBus } from "../../bus/command-bus";
+import { EventBus } from "../../bus/event-bus";
+import type { TabId } from "../../shared/types";
+import { createMockPlatform } from "../../test-utils/mock-platform";
+import type { TabsActivatedEvent, TabsClosedEvent } from "../tabs/tabs.shared";
+import pip from "./pip.main";
+import {
+  PIP_ACTIVATED,
+  PIP_CLOSE,
+  PIP_DEACTIVATED,
+  PIP_PLAY_STATE_CHANGED,
+  PIP_RETURN_TO_TAB,
+  PIP_TOGGLE_PLAY,
+  type PipCommands,
+  type PipEvents,
+} from "./pip.shared";
+
+type AllCommands = PipCommands & {
+  "tabs:activate": { payload: { tabId: TabId }; response: undefined };
+};
+type AllEvents = PipEvents & {
+  "tabs:activated": TabsActivatedEvent;
+  "tabs:closed": TabsClosedEvent;
+};
+
+/** Flush microtask queue so async handlers (executeJavaScript) resolve. */
+const flush = () => new Promise((r) => setTimeout(r, 10));
+
+const TAB_A = "tab-a" as TabId;
+const TAB_B = "tab-b" as TabId;
+
+function setup() {
+  const commands = new CommandBus<AllCommands>();
+  const events = new EventBus<AllEvents>();
+
+  const platform = createMockPlatform({
+    executeJavaScript: vi.fn(async () => false),
+  });
+
+  let activeTabId: TabId = TAB_B;
+
+  pip.register({
+    commands,
+    events,
+    platform,
+    getActiveTabId: () => activeTabId,
+  });
+
+  commands.handle("tabs:activate", async (payload) => {
+    const previous = activeTabId;
+    activeTabId = payload.tabId;
+    events.emit("tabs:activated", { tabId: payload.tabId, previousTabId: previous });
+  });
+
+  return { commands, events, platform };
+}
+
+/** Helper: set up PiP state by emitting a tab switch with video detected. */
+async function activatePip(ctx: ReturnType<typeof setup>) {
+  // First call: detect video → true. Second call: enter PiP → true.
+  (ctx.platform.executeJavaScript as ReturnType<typeof vi.fn>)
+    .mockResolvedValueOnce(true) // DETECT_VIDEO_JS
+    .mockResolvedValueOnce(true); // ENTER_PIP_JS
+
+  ctx.events.emit("tabs:activated", { tabId: TAB_B, previousTabId: TAB_A });
+  await flush();
+}
+
+describe("pip feature", () => {
+  describe("automatic activation", () => {
+    it("enters native PiP when switching away from a tab with playing video", async () => {
+      const { events, platform } = setup();
+
+      (platform.executeJavaScript as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(true) // detect
+        .mockResolvedValueOnce(true); // enter
+
+      const activated = vi.fn();
+      events.on(PIP_ACTIVATED, activated);
+
+      events.emit("tabs:activated", { tabId: TAB_B, previousTabId: TAB_A });
+      await flush();
+
+      // Should have called detect + enter PiP JS
+      expect(platform.executeJavaScript).toHaveBeenCalledTimes(2);
+      expect(activated).toHaveBeenCalledWith({ tabId: TAB_A });
+    });
+
+    it("does not activate PiP when no video is playing", async () => {
+      const { events, platform } = setup();
+      (platform.executeJavaScript as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+      const activated = vi.fn();
+      events.on(PIP_ACTIVATED, activated);
+
+      events.emit("tabs:activated", { tabId: TAB_B, previousTabId: TAB_A });
+      await flush();
+
+      expect(activated).not.toHaveBeenCalled();
+    });
+
+    it("does not activate PiP when there is no previous tab", async () => {
+      const { events, platform } = setup();
+
+      events.emit("tabs:activated", { tabId: TAB_B, previousTabId: null });
+      await flush();
+
+      expect(platform.executeJavaScript).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("pip:close", () => {
+    it("pauses video and exits native PiP", async () => {
+      const ctx = setup();
+      await activatePip(ctx);
+
+      const deactivated = vi.fn();
+      ctx.events.on(PIP_DEACTIVATED, deactivated);
+
+      await ctx.commands.send(PIP_CLOSE, undefined);
+
+      // Should have called pause + exit PiP
+      expect(ctx.platform.executeJavaScript).toHaveBeenCalledWith(
+        TAB_A,
+        expect.stringContaining("pause"),
+      );
+      expect(deactivated).toHaveBeenCalled();
+    });
+  });
+
+  describe("pip:toggle-play", () => {
+    it("toggles from playing to paused", async () => {
+      const ctx = setup();
+      await activatePip(ctx);
+
+      const playStateChanged = vi.fn();
+      ctx.events.on(PIP_PLAY_STATE_CHANGED, playStateChanged);
+
+      await ctx.commands.send(PIP_TOGGLE_PLAY, undefined);
+
+      expect(ctx.platform.executeJavaScript).toHaveBeenCalledWith(
+        TAB_A,
+        expect.stringContaining("pause"),
+      );
+      expect(playStateChanged).toHaveBeenCalledWith({ playing: false });
+    });
+
+    it("toggles from paused to playing", async () => {
+      const ctx = setup();
+      await activatePip(ctx);
+
+      // Pause first
+      await ctx.commands.send(PIP_TOGGLE_PLAY, undefined);
+
+      const playStateChanged = vi.fn();
+      ctx.events.on(PIP_PLAY_STATE_CHANGED, playStateChanged);
+
+      await ctx.commands.send(PIP_TOGGLE_PLAY, undefined);
+
+      expect(ctx.platform.executeJavaScript).toHaveBeenCalledWith(
+        TAB_A,
+        expect.stringContaining("play"),
+      );
+      expect(playStateChanged).toHaveBeenCalledWith({ playing: true });
+    });
+  });
+
+  describe("pip:return-to-tab", () => {
+    it("exits PiP and activates the source tab", async () => {
+      const ctx = setup();
+      await activatePip(ctx);
+
+      const deactivated = vi.fn();
+      ctx.events.on(PIP_DEACTIVATED, deactivated);
+
+      await ctx.commands.send(PIP_RETURN_TO_TAB, undefined);
+
+      expect(ctx.platform.executeJavaScript).toHaveBeenCalledWith(
+        TAB_A,
+        expect.stringContaining("exitPictureInPicture"),
+      );
+      expect(deactivated).toHaveBeenCalled();
+    });
+  });
+
+  describe("tab closed", () => {
+    it("dismisses PiP when source tab is closed", async () => {
+      const ctx = setup();
+      await activatePip(ctx);
+
+      const deactivated = vi.fn();
+      ctx.events.on(PIP_DEACTIVATED, deactivated);
+
+      ctx.events.emit("tabs:closed", { tabId: TAB_A, activatedTabId: TAB_B });
+
+      expect(deactivated).toHaveBeenCalled();
+    });
+
+    it("does not dismiss PiP when a different tab is closed", async () => {
+      const ctx = setup();
+      await activatePip(ctx);
+
+      const deactivated = vi.fn();
+      ctx.events.on(PIP_DEACTIVATED, deactivated);
+
+      ctx.events.emit("tabs:closed", { tabId: "tab-other" as TabId, activatedTabId: TAB_B });
+
+      expect(deactivated).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("auto-dismiss on source tab reactivated", () => {
+    it("exits PiP when the source tab becomes active again", async () => {
+      const ctx = setup();
+      await activatePip(ctx);
+
+      const deactivated = vi.fn();
+      ctx.events.on(PIP_DEACTIVATED, deactivated);
+
+      ctx.events.emit("tabs:activated", { tabId: TAB_A, previousTabId: TAB_B });
+
+      expect(ctx.platform.executeJavaScript).toHaveBeenCalledWith(
+        TAB_A,
+        expect.stringContaining("exitPictureInPicture"),
+      );
+      expect(deactivated).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/features/pip/pip.test.ts
+++ b/src/features/pip/pip.test.ts
@@ -82,8 +82,13 @@ describe("pip feature", () => {
       events.emit("tabs:activated", { tabId: TAB_B, previousTabId: TAB_A });
       await flush();
 
-      // Should have called detect + enter PiP JS
+      // Should have called detect + enter PiP JS with userGesture=true
       expect(platform.executeJavaScript).toHaveBeenCalledTimes(2);
+      expect(platform.executeJavaScript).toHaveBeenCalledWith(
+        TAB_A,
+        expect.stringContaining("requestPictureInPicture"),
+        true,
+      );
       expect(activated).toHaveBeenCalledWith({ tabId: TAB_A });
     });
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -67,6 +67,8 @@ import type {
   PinnedTabsCommands,
   PinnedTabsEvents,
 } from "../features/pinned-tabs/pinned-tabs.shared";
+import pip from "../features/pip/pip.main";
+import type { PipCommands, PipEvents } from "../features/pip/pip.shared";
 import settings from "../features/settings/settings.main";
 import {
   SETTINGS_GET,
@@ -178,6 +180,7 @@ type AllCommands = MergeRegistries<
     ExternalLinkCommands,
     PermissionsCommands,
     PdfReaderCommands,
+    PipCommands,
   ]
 >;
 
@@ -209,6 +212,7 @@ type AllEvents = MergeRegistries<
     ExternalLinkEvents,
     PermissionsEvents,
     PdfReaderEvents,
+    PipEvents,
   ]
 >;
 
@@ -364,6 +368,7 @@ if (gotLock) {
     externalLink.register(deps);
     permissions.register(deps);
     pdfReader.register(deps);
+    pip.register(deps);
 
     // Register debug state providers
     registerDebugState("tabs", () => {

--- a/src/platform/electron.ts
+++ b/src/platform/electron.ts
@@ -1490,10 +1490,10 @@ export class ElectronPlatform implements Platform {
     view.webContents.downloadURL(url);
   }
 
-  async executeJavaScript(tabId: TabId, code: string): Promise<unknown> {
+  async executeJavaScript(tabId: TabId, code: string, userGesture?: boolean): Promise<unknown> {
     const view = this.views.get(tabId);
     if (!view) return undefined;
-    return view.webContents.executeJavaScript(code);
+    return view.webContents.executeJavaScript(code, userGesture);
   }
 
   // ── Permissions ────────────────────────────────────────────────

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -186,5 +186,5 @@ export interface Platform {
   /** Trigger a download of the given URL in the tab's session. */
   downloadUrl(tabId: TabId, url: string): void;
   /** Execute JavaScript in the tab's webContents and return the result. */
-  executeJavaScript(tabId: TabId, code: string): Promise<unknown>;
+  executeJavaScript(tabId: TabId, code: string, userGesture?: boolean): Promise<unknown>;
 }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -18,6 +18,7 @@ import "../../features/installer/installer.feature";
 import "../../features/sub-tabs/sub-tabs.feature";
 import "../../features/permissions/permissions.feature";
 import "../../features/pdf-reader/pdf-reader.feature";
+import "../../features/pip/pip.feature";
 
 // All subscriptions wired — tell main process to start emitting events (phase 2)
 import { Shell, signalReady } from "./Shell";

--- a/src/test-utils/mock-platform.ts
+++ b/src/test-utils/mock-platform.ts
@@ -59,7 +59,7 @@ export function createMockPlatform(overrides: Partial<Platform> = {}): Platform 
     findInPage: vi.fn(),
     stopFindInPage: vi.fn(),
     insertCSS: vi.fn(async () => "css-key"),
-    removeInsertedCSS: vi.fn(),
+    removeInsertedCSS: vi.fn(async () => {}),
     onWindowOpen: vi.fn(() => () => {}),
     onNavigationBlock: vi.fn(() => () => {}),
     onProtocolRequest: vi.fn(() => () => {}),


### PR DESCRIPTION
## Summary
- Adds picture-in-picture support that automatically triggers `video.requestPictureInPicture()` when switching away from a tab with a playing video
- Uses Chromium's built-in PiP window for GPU compositing, always-on-top, and native playback controls
- Passes `userGesture=true` to bypass activation requirement on repeated PiP entries
- Includes feature spec, store, main/renderer integration, design system page, and tests

## Test plan
- [ ] Verify PiP activates when switching away from a tab playing a video
- [ ] Verify PiP exits when switching back to the tab
- [ ] Verify PiP does not activate for paused videos
- [ ] Verify PiP toggle command works from command palette
- [ ] Run `bun run verify` to confirm all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Picture-in-Picture (PiP) mode: floating window with play/pause, return-to-tab, and close controls; auto-activates when leaving a tab playing video and dismisses when returning or closing the source tab.
  * Seamless playback during PiP transfer.

* **Documentation**
  * Added PiP Player design page and a detailed Picture-in-Picture feature specification.

* **Tests**
  * Added end-to-end and unit tests covering PiP activation, controls, and lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->