### PR TITLE
Keep pinned tab active when switching workspaces

### DIFF
--- a/src/features/workspaces/workspaces.main.ts
+++ b/src/features/workspaces/workspaces.main.ts
@@ -6,6 +6,7 @@ import { defineFeature } from "../../shared/define-feature";
 import { featureState } from "../../shared/feature-state";
 import { logError } from "../../shared/log";
 import type { TabId, WindowId, WorkspaceId } from "../../shared/types";
+import { isPinned } from "../pinned-tabs/pinned-tabs.main";
 import type { Tab, TabsCommands, TabsEvents } from "../tabs/tabs.shared";
 import {
   TABS_ACTIVATE,
@@ -126,19 +127,24 @@ export default defineFeature<Deps>({
         pendingHideAllTabsTimer = null;
       }
 
-      // Save current ws active tab
-      if (previousWsId) {
+      const activeTabId = getActiveTabId() ?? null;
+      const activePinned = activeTabId ? isPinned(activeTabId) : false;
+
+      // Save current ws active tab (skip pinned tabs — they're global)
+      if (previousWsId && !activePinned) {
         const prevWs = workspaces.get(previousWsId);
         if (prevWs) {
-          prevWs.activeTabId = getActiveTabId() ?? null;
+          prevWs.activeTabId = activeTabId;
         }
       }
 
       // Switch
       setActiveWorkspaceId(workspaceId);
 
-      // Activate new ws's tab
-      if (ws.activeTabId) {
+      // If a pinned tab is active, keep it — pinned tabs span all workspaces
+      if (activePinned) {
+        // nothing to do — the pinned tab stays shown
+      } else if (ws.activeTabId) {
         // TABS_ACTIVATE hides the previous active tab and shows the new one
         await commands.send(TABS_ACTIVATE, { tabId: ws.activeTabId });
       } else {

--- a/src/features/workspaces/workspaces.main.ts
+++ b/src/features/workspaces/workspaces.main.ts
@@ -104,6 +104,17 @@ export default defineFeature<Deps>({
       });
     }
 
+    // Keep workspace activeTabId up-to-date on every non-pinned tab activation,
+    // so the workspace always remembers the last workspace-local tab even if the
+    // user later clicks a pinned tab before switching workspaces.
+    events.on(TABS_ACTIVATED, ({ tabId }) => {
+      const wsId = getActiveWorkspaceId();
+      if (!wsId || !tabId) return;
+      if (isPinned(tabId)) return;
+      const ws = workspaces.get(wsId);
+      if (ws) ws.activeTabId = tabId;
+    });
+
     // Track original URLs when tabs are first bookmarked
     events.on(TABS_UPDATED, (payload) => {
       const { tab } = payload;

--- a/src/features/workspaces/workspaces.test.ts
+++ b/src/features/workspaces/workspaces.test.ts
@@ -188,6 +188,54 @@ describe("workspaces commands", () => {
       vi.useRealTimers();
     });
 
+    it("remembers last non-pinned tab when pinned tab is active during switch", async () => {
+      vi.useFakeTimers();
+      const { commands, events, platform, setActiveTabId, setActiveWsId } = setup();
+      const ws1Id = await commands.send(WORKSPACES_CREATE, {
+        name: "Work",
+        color: "blue",
+        icon: "W",
+      });
+      const ws2Id = await commands.send(WORKSPACES_CREATE, {
+        name: "Personal",
+        color: "red",
+        icon: "P",
+      });
+      setActiveWsId(ws1Id);
+
+      // Activate a non-pinned tab — TABS_ACTIVATED listener saves it to ws1
+      const tabY = "tab-y" as TabId;
+      events.emit(TABS_ACTIVATED, { tabId: tabY, previousTabId: null });
+      setActiveTabId(tabY);
+
+      // Now switch to a pinned tab
+      const pinnedTab = "pinned-t1" as TabId;
+      (isPinned as ReturnType<typeof vi.fn>).mockImplementation((id: TabId) => id === pinnedTab);
+      events.emit(TABS_ACTIVATED, { tabId: pinnedTab, previousTabId: tabY });
+      setActiveTabId(pinnedTab);
+
+      // Switch to ws2 while pinned tab is active
+      await commands.send(WORKSPACES_SWITCH, { workspaceId: ws2Id });
+      vi.runAllTimers();
+
+      // Switch back to ws1 — should restore tabY (the last non-pinned tab), not the pinned tab
+      // Spy on TABS_ACTIVATE calls to see which tab gets activated
+      const activateCalls: unknown[] = [];
+      const origSend = commands.send.bind(commands);
+      vi.spyOn(commands, "send").mockImplementation(async (name: string, payload: unknown) => {
+        if (name === TABS_ACTIVATE) activateCalls.push(payload);
+        return origSend(name, payload);
+      });
+
+      (isPinned as ReturnType<typeof vi.fn>).mockReturnValue(false);
+      setActiveTabId(undefined);
+      await commands.send(WORKSPACES_SWITCH, { workspaceId: ws1Id });
+
+      expect(activateCalls).toContainEqual({ tabId: tabY });
+
+      vi.useRealTimers();
+    });
+
     it("no-ops when switching to same workspace", async () => {
       const { commands, events, setActiveWsId } = setup();
       const wsId = await commands.send(WORKSPACES_CREATE, {

--- a/src/features/workspaces/workspaces.test.ts
+++ b/src/features/workspaces/workspaces.test.ts
@@ -10,6 +10,12 @@ vi.mock("../tabs/tabs.main", () => ({
   getTabsForWorkspace: vi.fn(() => []),
 }));
 
+// Mock pinned-tabs.main
+vi.mock("../pinned-tabs/pinned-tabs.main", () => ({
+  isPinned: vi.fn(() => false),
+}));
+
+import { isPinned } from "../pinned-tabs/pinned-tabs.main";
 import { getTabsForWorkspace } from "../tabs/tabs.main";
 import {
   TABS_ACTIVATE,
@@ -148,6 +154,37 @@ describe("workspaces commands", () => {
           workspaceName: "Personal",
         }),
       );
+      vi.useRealTimers();
+    });
+
+    it("keeps pinned tab active when switching workspaces", async () => {
+      vi.useFakeTimers();
+      const { commands, events, platform, setActiveTabId, setActiveWsId } = setup();
+      const ws1Id = await commands.send(WORKSPACES_CREATE, {
+        name: "Work",
+        color: "blue",
+        icon: "W",
+      });
+      const ws2Id = await commands.send(WORKSPACES_CREATE, {
+        name: "Personal",
+        color: "red",
+        icon: "P",
+      });
+      setActiveWsId(ws1Id);
+      setActiveTabId("pinned-t1" as TabId);
+      (isPinned as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+      const activated = vi.fn();
+      events.on(TABS_ACTIVATED, activated);
+
+      await commands.send(WORKSPACES_SWITCH, { workspaceId: ws2Id });
+      vi.runAllTimers();
+
+      // Should NOT hide tabs or deactivate — the pinned tab stays visible
+      expect(platform.hideAllTabs).not.toHaveBeenCalled();
+      expect(activated).not.toHaveBeenCalled();
+
+      (isPinned as ReturnType<typeof vi.fn>).mockReturnValue(false);
       vi.useRealTimers();
     });
 


### PR DESCRIPTION
## Summary
- Pinned tabs now remain active when switching workspaces instead of being replaced by the target workspace's tab
- The workspace switch handler checks if the active tab is pinned and, if so, skips both saving it as the workspace's `activeTabId` and activating a different tab
- Adds unit test verifying pinned tabs are preserved across workspace switches

## Test plan
- [x] Unit test: pinned tab stays active (no `hideAllTabs`, no `TABS_ACTIVATED` event)
- [x] All 585 existing tests pass
- [x] Manual verification via debug server: pin a tab, switch workspaces, confirm pinned tab remains active
- [x] Normal (non-pinned) workspace switching still restores the correct tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace switching now preserves pinned tabs: pinned tabs stay visible/active and are not recorded as the workspace's last-active tab; last non-pinned tabs remain the MRU target when returning to a workspace. A listener keeps MRU state up-to-date on non-pinned activations.

* **Tests**
  * Added tests covering pinned-tab behavior during workspace switches and MRU restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->