### PR TITLE
Show link URL in Copy link context menu action

### DIFF
--- a/src/features/tab-context-menu/tab-context-menu.main.ts
+++ b/src/features/tab-context-menu/tab-context-menu.main.ts
@@ -63,6 +63,16 @@ function getSearchUrl(provider: SearchProvider, query: string): string {
   return provider.urlTemplate.replace("{query}", encodeURIComponent(query));
 }
 
+const MAX_URL_DISPLAY_LENGTH = 50;
+
+function formatUrlForDisplay(url: string): string {
+  let display = url.replace(/^https?:\/\//, "").replace(/\/$/, "");
+  if (display.length > MAX_URL_DISPLAY_LENGTH) {
+    display = `${display.slice(0, MAX_URL_DISPLAY_LENGTH - 1)}\u2026`;
+  }
+  return display;
+}
+
 export default defineFeature<Deps>({
   register(deps) {
     const { commands, events, platform } = deps;
@@ -154,7 +164,7 @@ export default defineFeature<Deps>({
       // Link context
       if (params.linkURL) {
         items.push({
-          label: "Copy link",
+          label: `Copy link \u2014 ${formatUrlForDisplay(params.linkURL)}`,
           icon: "copy",
           action: () => {
             commands

--- a/src/features/tab-context-menu/tab-context-menu.test.ts
+++ b/src/features/tab-context-menu/tab-context-menu.test.ts
@@ -227,12 +227,31 @@ describe("tab-context-menu", () => {
       commands.unhandle?.(CONTEXT_MENU_SHOW);
       commands.handle(CONTEXT_MENU_SHOW, async (payload) => {
         expect(payload.items).toHaveLength(1);
-        expect(payload.items[0]).toEqual({ label: "Copy link", icon: "copy" });
+        expect(payload.items[0]).toEqual({
+          label: "Copy link \u2014 example.com",
+          icon: "copy",
+        });
         return -1;
       });
 
       emitTabCreated(events);
       await triggerContextMenu(tabEventCallbacks, { linkURL: "https://example.com" });
+    });
+
+    it("truncates long URLs in the label", async () => {
+      const { events, commands, tabEventCallbacks } = setup();
+      commands.unhandle?.(CONTEXT_MENU_SHOW);
+      const longUrl =
+        "https://example.com/very/long/path/that/exceeds/the/maximum/display/length/for/urls";
+      commands.handle(CONTEXT_MENU_SHOW, async (payload) => {
+        const label = payload.items[0]?.label ?? "";
+        expect(label).toMatch(/^Copy link \u2014 .+\u2026$/);
+        expect(label.length).toBeLessThanOrEqual("Copy link \u2014 ".length + 50);
+        return -1;
+      });
+
+      emitTabCreated(events);
+      await triggerContextMenu(tabEventCallbacks, { linkURL: longUrl });
     });
 
     it("copies link URL when selected", async () => {
@@ -309,7 +328,7 @@ describe("tab-context-menu", () => {
         expect(payload.items.map((i: { label: string }) => i.label)).toEqual([
           "Copy",
           "Search with Google",
-          "Copy link",
+          "Copy link \u2014 example.com",
           "Copy image",
           "Download image",
         ]);


### PR DESCRIPTION
## Summary
- The "Copy link" context menu item now displays the link URL after the label (e.g. `Copy link — example.com/page`)
- Protocol prefix (`https://`) is stripped and long URLs are truncated at 50 characters with an ellipsis

## Test plan
- [x] Existing context menu tests updated
- [x] New test for long URL truncation
- [ ] Manually verify context menu on a page with links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Link context menu now displays the URL being copied alongside the "Copy link" action, providing clearer visibility of which link you're duplicating. Long URLs are automatically formatted and truncated for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->