### PR TITLE
Enable isolated agent verification of the Electron browser

### DIFF
--- a/.codex/skills/browse-app/SKILL.md
+++ b/.codex/skills/browse-app/SKILL.md
@@ -5,6 +5,16 @@ description: Launch, inspect and interact with the Chiaroscuro Electron app or i
 
 # Browse and verify Chiaroscuro
 
+When the user asks to run, launch, or open the **dev browser on Windows**, deploy
+the complete built app to Windows and run Windows Electron with its local built
+renderer. This is the default for the user's manual testing. Read the
+[Windows deployment workflow](references/development.md#windows-dev-browser-for-manual-testing)
+before launching. The browser must remain usable after WSL or the agent session
+stops. Set `ELECTRON_RENDERER_URL` to the deployed renderer's local `file://` URL
+to select the app's separate dev identity. Do not point it at a server, start
+Vite, create `.dev-server-pid`, or substitute an isolated test session for this
+request. Use HMR only when the user explicitly requests hot reload.
+
 For verifying changes, use the existing Electron fixture through the shared
 controller/scenarios. Read [agent verification](../../../docs/testing/agent-verification.md)
 for target relationships, evidence scope, Windows prerequisites and genuine gaps.
@@ -31,13 +41,20 @@ windows via the desktop capture. Ozone headless cannot provide composed evidence
 use the Linux Xvfb/Openbox/xcompmgr scenario runner or a permitted native Windows desktop.
 Capture manifests explicitly report missing/unsupported evidence.
 
+For title-bar hover/click bugs, compare desktop input with CDP: native draggable
+regions can suppress pointer events even when Playwright clicks succeed. Run
+`bun run verify:app:win --address-bar` for the icon/padding diagnostic and Reload
+positive control described in the verification guide. Report its actual outcome
+and any partial evidence; do not treat a CDP-only pass as proof of native hit testing.
+
 `stop`, EOF or a termination signal cleans up the controller's own process and
 profile. When using `playwright-cli` with the controller's CDP URL, keep ownership
 with the controller: send it `stop` to tear down. Do not run the personal dev
 teardown script against an isolated session.
 
-For HMR development sessions, reconnecting an already running app, or the design
-system website, read [development browser workflow](references/development.md).
+For Windows deployment, explicitly requested HMR sessions, reconnecting an
+already running app, or the design system website, read
+[development browser workflow](references/development.md).
 The existing `launch-docs.sh`, `connect-app.sh` and `playwright-cli` integration
 remain available. Design-system verification complements Electron verification;
 it does not substitute for native view/focus/process checks.

--- a/.codex/skills/browse-app/SKILL.md
+++ b/.codex/skills/browse-app/SKILL.md
@@ -1,166 +1,43 @@
 ---
 name: browse-app
-description: Launch and interact with the Chiaroscuro Electron app or design system website via playwright-cli. Use when you need to start the app, navigate pages, click elements, take screenshots, or inspect console/network state. Trigger phrases include "launch the app", "start the app", "open the app", "browse the app", "take a screenshot of the app".
+description: Launch, inspect and interact with the Chiaroscuro Electron app or its design system. Use for app screenshots, UI verification, target selection and reproducible browser scenarios.
 ---
 
-# Goal
+# Browse and verify Chiaroscuro
 
-Launch and interact with the running Chiaroscuro app **or the design system website** using `playwright-cli`.
+For verifying changes, use the existing Electron fixture through the shared
+controller/scenarios. Read [agent verification](../../../docs/testing/agent-verification.md)
+for target relationships, evidence scope, Windows prerequisites and genuine gaps.
 
-## Invocation
+- `bun run build && bun run verify:app` runs deterministic scenarios on the real
+  app, including restart, sub-tabs, native popup focus, downloads and drag.
+- `bun run agent:app` launches an isolated Electron instance and local fixtures.
+  Keep stdin open (a PTY works). It prints readiness, target IDs, a CDP URL and an
+  artifact directory. Send JSONL actions; discover their schema with
+  `bun run agent:app --help`.
+- `bun run verify:app:win` runs the same fixture natively on Windows from WSL;
+  add `--interactive` for the controller.
+- `launch-app.sh --isolated` and `launch-app.sh --verify` delegate to these paths.
+  They do not use a personal browsing profile or fixed debug port.
 
-- `/browse-app` — Launch the Electron app and connect
-- `/browse-app design-system` — Launch the design system website
+Start with `targets`, then `inspect` the correct ID. Built-in pages share the
+shell renderer; sub-tabs and palettes are distinct targets. Use visible UI
+input (`click`, `fill`, `press`, `shortcut`, `drag`) to verify behavior. Commands
+are for setup/diagnosis. Rediscover native target IDs after `restart`.
 
-## Targets
+Use `capture` and inspect its images. `*.renderer.png` and Playwright screenshots
+cover one renderer only. `*.composed.png` includes native view layers and child
+windows via the desktop capture. Ozone headless cannot provide composed evidence;
+use the Linux Xvfb/Openbox/xcompmgr scenario runner or a permitted native Windows desktop.
+Capture manifests explicitly report missing/unsupported evidence.
 
-|               | **App**                                 | **Design System**              |
-| ------------- | --------------------------------------- | ------------------------------ |
-| What          | Electron browser app                    | Vite-served documentation site |
-| Launch        | `launch-app.sh`                         | `launch-docs.sh`              |
-| Teardown      | `teardown-app.sh`                       | `teardown-docs.sh`            |
-| Build         | `electron-vite build` + sync to Windows | `bun run docs:dev --host`     |
-| Window chrome | Yes (custom title bar)                  | No                            |
+`stop`, EOF or a termination signal cleans up the controller's own process and
+profile. When using `playwright-cli` with the controller's CDP URL, keep ownership
+with the controller: send it `stop` to tear down. Do not run the personal dev
+teardown script against an isolated session.
 
-## Prerequisites
-
-`playwright-cli` must be installed globally (already on `PATH`). No MCP configuration needed.
-
-## Browser Interaction via `playwright-cli`
-
-All browser interaction uses `playwright-cli` via the Bash tool. The CLI manages its own headless Chromium browser with persistent sessions.
-
-### Key commands
-
-```bash
-# Browser lifecycle
-playwright-cli open [url]             # open browser (optionally navigate)
-playwright-cli open --persistent      # use persistent profile (survives browser restart)
-playwright-cli close                  # close browser
-
-# Page inspection (also returned automatically after most commands)
-playwright-cli snapshot              # get page accessibility tree with element refs
-playwright-cli screenshot            # screenshot current page
-playwright-cli screenshot <ref>      # screenshot specific element
-playwright-cli screenshot --full-page # full scrollable page
-
-# Interaction (refs come from snapshot output)
-playwright-cli click <ref>           # click element
-playwright-cli fill <ref> <text>     # fill input
-playwright-cli type <text>           # type text into focused element
-playwright-cli press <key>           # press key (e.g., Enter, ArrowDown)
-playwright-cli hover <ref>           # hover over element
-playwright-cli select <ref> <val>    # select dropdown option
-playwright-cli resize <w> <h>        # resize viewport
-playwright-cli goto <url>            # navigate to URL
-
-# Debugging
-playwright-cli console               # list console messages
-playwright-cli console error         # errors only
-playwright-cli network               # list network requests
-playwright-cli eval '<func>'         # evaluate JS on page
-
-# Monitoring
-playwright-cli show                  # open visual dashboard for all sessions
-
-# Tabs
-playwright-cli tab-list              # list tabs
-playwright-cli tab-new [url]         # open new tab
-playwright-cli tab-select <n>        # switch to tab
-playwright-cli tab-close [index]     # close tab
-```
-
-### Automatic snapshots
-
-Commands like `goto`, `click`, `fill` etc. automatically output a snapshot of the page state after execution. You don't need to run `playwright-cli snapshot` separately unless you want to refresh the view without performing an action.
-
-### Workflow pattern
-
-1. Take a `snapshot` to get element refs
-2. Use refs to `click`, `fill`, `hover` etc.
-3. Take `screenshot` to verify visual state
-4. Read the screenshot image file with the Read tool to see the result
-5. Repeat
-
-## WSL Environment Setup
-
-This project runs in WSL2. The Electron app runs on Windows.
-
-### CDP Port Configuration
-
-The CDP port is read from `ELECTRON_APP_PORT` in `.env.local`. All scripts (`launch-app.sh`, `connect-app.sh`, `teardown-app.sh`) use this value automatically. If the env var is missing, scripts will error with instructions.
-
-You can override with `--cdp-port PORT` on any script.
-
-### Starting the app (Electron)
-
-The launcher builds, syncs to Windows, launches Electron, and auto-connects `playwright-cli` via CDP.
-
-```bash
-.codex/skills/browse-app/scripts/launch-app.sh                         # build if needed + launch + connect
-.codex/skills/browse-app/scripts/launch-app.sh --rebuild                # force rebuild
-```
-
-`playwright-cli` connects directly to the Electron renderer via CDP — no separate browser window. You can interact with the actual Electron UI including WebContentsView tabs.
-
-To reconnect manually (e.g., after daemon dies):
-
-```bash
-.codex/skills/browse-app/scripts/connect-app.sh
-```
-
-### Starting the design system
-
-```bash
-.codex/skills/browse-app/scripts/launch-docs.sh
-```
-
-This starts Vite, swaps `.playwright/cli.config.json` to standalone browser mode (backing up any CDP config), and auto-opens the page in `playwright-cli`. No manual `playwright-cli open` needed.
-
-### Stopping
-
-```bash
-# Close playwright-cli browser:
-playwright-cli close
-
-# For app:
-.codex/skills/browse-app/scripts/teardown-app.sh
-
-# For design system:
-.codex/skills/browse-app/scripts/teardown-docs.sh
-```
-
-`teardown-docs.sh` restores the CDP config backup if one exists, so subsequent `launch-app.sh` / `connect-app.sh` runs work correctly.
-
-## Config Management
-
-`playwright-cli` reads `.playwright/cli.config.json` from the project root to decide how to connect:
-- **App (CDP)**: `connect-app.sh` writes a config with `"cdpEndpoint"` pointing at Electron's debugging port.
-- **Design system (standalone)**: `launch-docs.sh` replaces the config with one that has no `cdpEndpoint`, so `playwright-cli` launches its own Chromium.
-
-The scripts handle backup/restore automatically. If you get a `connectOverCDP: Timeout` error when browsing the design system, the CDP config is active — run `launch-docs.sh` to fix it.
-
-## Connect Workflow
-
-1. Run the appropriate launch script (foreground, not background — these complete in seconds):
-   - **App:** `launch-app.sh` — builds, launches Electron, and auto-connects `playwright-cli` via CDP
-   - **Design system:** `launch-docs.sh` — starts Vite and auto-opens in `playwright-cli`
-2. Run `playwright-cli snapshot` to confirm the page loaded
-3. Run `playwright-cli screenshot` and read the image to confirm visuals
-4. For app, use `playwright-cli tab-list` to see all Electron pages and `playwright-cli tab-select <n>` to switch
-
-## Timeouts
-
-Most scripts should complete in a few seconds. The docs launcher can wait up to about 30 seconds for Vite to become ready; use `timeout: 30000` for it and shorter timeouts for the others. Never run them in the background — you need the output immediately. If a script takes longer than expected, read the output and fix the root cause.
-
-## Tips
-
-- Save screenshots to the scratchpad directory, not the project
-- Always `snapshot` before interacting to get fresh element refs
-- When something looks wrong, take a snapshot too to understand the DOM structure
-- Use `--full-page` on screenshots to capture scrollable content
-
-## Failure handling
-
-- The launch scripts poll for readiness internally and exit on timeout — **do not manually probe CDP or Vite ports**. If the script fails, read its output and act on it directly.
-- If `launch-app.sh` fails (CDP timeout, Electron didn't start), **fall back to the design system** (`launch-docs.sh`) for UI verification. Run `teardown-app.sh` first to clean up.
+For HMR development sessions, reconnecting an already running app, or the design
+system website, read [development browser workflow](references/development.md).
+The existing `launch-docs.sh`, `connect-app.sh` and `playwright-cli` integration
+remain available. Design-system verification complements Electron verification;
+it does not substitute for native view/focus/process checks.

--- a/.codex/skills/browse-app/references/development.md
+++ b/.codex/skills/browse-app/references/development.md
@@ -4,7 +4,7 @@ Launch and interact with the running Chiaroscuro app **or the design system webs
 
 ## Invocation
 
-- `/browse-app` — Launch the Electron app and connect
+- `/browse-app` or “run the dev browser on Windows” — Deploy the complete build to Windows and launch it for manual testing
 - `/browse-app design-system` — Launch the design system website
 
 ## Targets
@@ -12,14 +12,14 @@ Launch and interact with the running Chiaroscuro app **or the design system webs
 |               | **App**                                 | **Design System**              |
 | ------------- | --------------------------------------- | ------------------------------ |
 | What          | Electron browser app                    | Vite-served documentation site |
-| Launch        | `launch-app.sh`                         | `launch-docs.sh`              |
-| Teardown      | `teardown-app.sh`                       | `teardown-docs.sh`            |
+| Launch        | Windows deployment procedure below     | `launch-docs.sh`              |
+| Teardown      | Close the native app window             | `teardown-docs.sh`            |
 | Build         | `electron-vite build` + sync to Windows | `bun run docs:dev --host`     |
 | Window chrome | Yes (custom title bar)                  | No                            |
 
 ## Prerequisites
 
-`playwright-cli` must be installed globally (already on `PATH`). No MCP configuration needed.
+Windows deployment requires WSL interop, native Windows Bun/Node and the repository build tools. `playwright-cli` is optional for inspection; manual testing must not depend on a debugging connection.
 
 ## Browser Interaction via `playwright-cli`
 
@@ -81,28 +81,66 @@ Commands like `goto`, `click`, `fill` etc. automatically output a snapshot of th
 
 This project runs in WSL2. The Electron app runs on Windows.
 
-### CDP Port Configuration
+### Windows dev browser for manual testing
 
-The CDP port is read from `ELECTRON_APP_PORT` in `.env.local`. All scripts (`launch-app.sh`, `connect-app.sh`, `teardown-app.sh`) use this value automatically. If the env var is missing, scripts will error with instructions.
+When the user asks to run, launch or open the dev browser on Windows, **build and
+deploy the app to Windows, then run it there using its built renderer files**.
+The browser must keep working when the agent turn ends or WSL stops. Do not use
+Vite/HMR or an isolated automation session for this request. Do not create
+`.dev-server-pid`.
 
-You can override with `--cdp-port PORT` on any script.
+1. Run `bun run build` in the repository to build the current main, preload and
+   renderer code.
+2. Resolve the Windows user's `%USERPROFILE%` through PowerShell. Deploy into
+   `%USERPROFILE%\.chiaroscuro-dev`, converting that path with `wslpath` for WSL
+   file operations. Gracefully close an existing instance of this dev app before
+   replacing its files so the launch cannot reuse an older process. Sync the
+   **whole** `out/` directory, including `out/renderer/`,
+   and `resources/`. Copy `package.json`, `bun.lock` and `bunfig.toml`. Preserve the
+   user's browser profile and unrelated files; scope sync deletion to the build
+   and resource directories.
+3. In that Windows directory, use native Windows Bun to run
+   `bun install --frozen-lockfile` and `bun run setup:electron`. Follow the runtime
+   versions pinned by the repository. Existing portable Windows runtimes may be
+   added to the launching PowerShell process's PATH.
+4. In the launching PowerShell process, clear `ELECTRON_RENDERER_URL`,
+   `ELECTRON_RUN_AS_NODE`, `NODE_ENV`, `DATA_DIR`, `CHIAROSCURO_AUTOMATION` and
+   `CHIAROSCURO_DEBUG_TOKEN` so inherited dev/test settings cannot redirect this
+   launch. Then set `ELECTRON_RENDERER_URL` to the deployed renderer's local file
+   URL: `([Uri](Join-Path $PSScriptRoot 'out\renderer\index.html')).AbsoluteUri`
+   in a PowerShell script stored in the deployment directory. The app uses this
+   variable to select its separate dev identity/profile; leaving it unset can
+   collide with an installed production browser. It must be a `file://` URL,
+   with no dependency on a renderer server. Launch
+   `node_modules\electron\dist\electron.exe` with `.` as its app argument and
+   the deployed directory as its working directory, using `Start-Process`.
+   Leave the native process running for the user.
+5. Confirm the Windows app window is responsive and its actual UI has loaded.
+   When CDP is available, check that the shell URL is the deployed
+   `file://.../out/renderer/index.html`. Otherwise inspect the native window.
+   A debugger connection failure must not terminate a usable manual-test app.
 
-### Starting the app (Electron)
+The current `launch-app.sh` default and `bun run dev:win` are **HMR launchers**:
+they copy only main/preload and serve the renderer from WSL. Do not use them for
+the default Windows manual-testing request. Follow the deployment procedure above.
 
-The launcher builds, syncs to Windows, launches Electron, and auto-connects `playwright-cli` via CDP.
+### Explicitly requested hot reload
+
+Only when the user explicitly asks for HMR/hot reload, use `bun run dev:win` or
+`.codex/skills/browse-app/scripts/launch-app.sh --rebuild`. These require Vite in
+WSL to remain running and are unsuitable for an independent manual-test session.
+
+### Optional CDP inspection
+
+For an app launched with `--remote-debugging-port=PORT`, reconnect using:
 
 ```bash
-.codex/skills/browse-app/scripts/launch-app.sh                         # build if needed + launch + connect
-.codex/skills/browse-app/scripts/launch-app.sh --rebuild                # force rebuild
+.codex/skills/browse-app/scripts/connect-app.sh --cdp-port PORT
 ```
 
-`playwright-cli` connects directly to the Electron renderer via CDP — no separate browser window. You can interact with the actual Electron UI including WebContentsView tabs.
-
-To reconnect manually (e.g., after daemon dies):
-
-```bash
-.codex/skills/browse-app/scripts/connect-app.sh
-```
+The connection scripts also accept `ELECTRON_APP_PORT` from `.env.local` when no
+port override is supplied. CDP attaches to the actual Electron renderers; the
+standalone design-system workflow launches its own Chromium browser.
 
 ### Starting the design system
 
@@ -118,14 +156,15 @@ This starts Vite, swaps `.playwright/cli.config.json` to standalone browser mode
 # Close playwright-cli browser:
 playwright-cli close
 
-# For app:
-.codex/skills/browse-app/scripts/teardown-app.sh
+# For the manually deployed app: close its Windows window.
+# For an explicitly requested HMR/CDP session:
+.codex/skills/browse-app/scripts/teardown-app.sh --cdp-port PORT
 
 # For design system:
 .codex/skills/browse-app/scripts/teardown-docs.sh
 ```
 
-`teardown-docs.sh` restores the CDP config backup if one exists, so subsequent `launch-app.sh` / `connect-app.sh` runs work correctly.
+`teardown-docs.sh` restores the CDP config backup if one exists, so subsequent `connect-app.sh` runs work correctly.
 
 ## Config Management
 
@@ -137,8 +176,8 @@ The scripts handle backup/restore automatically. If you get a `connectOverCDP: T
 
 ## Connect Workflow
 
-1. Run the appropriate launch script (foreground, not background — these complete in seconds):
-   - **App:** `launch-app.sh` — builds, launches Electron, and auto-connects `playwright-cli` via CDP
+1. Launch the requested target:
+   - **App:** follow Windows deployment above; connect separately if CDP inspection is needed
    - **Design system:** `launch-docs.sh` — starts Vite and auto-opens in `playwright-cli`
 2. Run `playwright-cli snapshot` to confirm the page loaded
 3. Run `playwright-cli screenshot` and read the image to confirm visuals
@@ -146,7 +185,7 @@ The scripts handle backup/restore automatically. If you get a `connectOverCDP: T
 
 ## Timeouts
 
-Most scripts should complete in a few seconds. The docs launcher can wait up to about 30 seconds for Vite to become ready; use `timeout: 30000` for it and shorter timeouts for the others. Never run them in the background — you need the output immediately. If a script takes longer than expected, read the output and fix the root cause.
+Allow the build and Windows dependency installation to complete before launching. The docs launcher can wait up to about 30 seconds for Vite readiness. Inspect failures before proceeding; successful process creation alone does not establish that the UI loaded.
 
 ## Tips
 
@@ -158,4 +197,4 @@ Most scripts should complete in a few seconds. The docs launcher can wait up to 
 ## Failure handling
 
 - The launch scripts poll for readiness internally and exit on timeout — **do not manually probe CDP or Vite ports**. If the script fails, read its output and act on it directly.
-- If app launch fails, preserve the error and clean up with `teardown-app.sh`. A design-system preview can inspect components, but does not verify the Electron app. Report the app check as unavailable.
+- If deployment or native app launch fails, preserve the error and report it. An optional CDP connection failure does not establish an app launch failure; inspect the native window and leave a usable manual-test app running. A design-system preview does not verify the Electron app.

--- a/.codex/skills/browse-app/references/development.md
+++ b/.codex/skills/browse-app/references/development.md
@@ -1,0 +1,161 @@
+# Goal
+
+Launch and interact with the running Chiaroscuro app **or the design system website** using `playwright-cli`.
+
+## Invocation
+
+- `/browse-app` — Launch the Electron app and connect
+- `/browse-app design-system` — Launch the design system website
+
+## Targets
+
+|               | **App**                                 | **Design System**              |
+| ------------- | --------------------------------------- | ------------------------------ |
+| What          | Electron browser app                    | Vite-served documentation site |
+| Launch        | `launch-app.sh`                         | `launch-docs.sh`              |
+| Teardown      | `teardown-app.sh`                       | `teardown-docs.sh`            |
+| Build         | `electron-vite build` + sync to Windows | `bun run docs:dev --host`     |
+| Window chrome | Yes (custom title bar)                  | No                            |
+
+## Prerequisites
+
+`playwright-cli` must be installed globally (already on `PATH`). No MCP configuration needed.
+
+## Browser Interaction via `playwright-cli`
+
+This personal development workflow uses `playwright-cli` via the shell. For isolated verification use the shared controller described in SKILL.md. The CLI manages its own headless Chromium browser with persistent sessions.
+
+### Key commands
+
+```bash
+# Browser lifecycle
+playwright-cli open [url]             # open browser (optionally navigate)
+playwright-cli open --persistent      # use persistent profile (survives browser restart)
+playwright-cli close                  # close browser
+
+# Page inspection (also returned automatically after most commands)
+playwright-cli snapshot              # get page accessibility tree with element refs
+playwright-cli screenshot            # screenshot current page
+playwright-cli screenshot <ref>      # screenshot specific element
+playwright-cli screenshot --full-page # full scrollable page
+
+# Interaction (refs come from snapshot output)
+playwright-cli click <ref>           # click element
+playwright-cli fill <ref> <text>     # fill input
+playwright-cli type <text>           # type text into focused element
+playwright-cli press <key>           # press key (e.g., Enter, ArrowDown)
+playwright-cli hover <ref>           # hover over element
+playwright-cli select <ref> <val>    # select dropdown option
+playwright-cli resize <w> <h>        # resize viewport
+playwright-cli goto <url>            # navigate to URL
+
+# Debugging
+playwright-cli console               # list console messages
+playwright-cli console error         # errors only
+playwright-cli network               # list network requests
+playwright-cli eval '<func>'         # evaluate JS on page
+
+# Monitoring
+playwright-cli show                  # open visual dashboard for all sessions
+
+# Tabs
+playwright-cli tab-list              # list tabs
+playwright-cli tab-new [url]         # open new tab
+playwright-cli tab-select <n>        # switch to tab
+playwright-cli tab-close [index]     # close tab
+```
+
+### Automatic snapshots
+
+Commands like `goto`, `click`, `fill` etc. automatically output a snapshot of the page state after execution. You don't need to run `playwright-cli snapshot` separately unless you want to refresh the view without performing an action.
+
+### Workflow pattern
+
+1. Take a `snapshot` to get element refs
+2. Use refs to `click`, `fill`, `hover` etc.
+3. Take `screenshot` to verify visual state
+4. Read the screenshot image file with the Read tool to see the result
+5. Repeat
+
+## WSL Environment Setup
+
+This project runs in WSL2. The Electron app runs on Windows.
+
+### CDP Port Configuration
+
+The CDP port is read from `ELECTRON_APP_PORT` in `.env.local`. All scripts (`launch-app.sh`, `connect-app.sh`, `teardown-app.sh`) use this value automatically. If the env var is missing, scripts will error with instructions.
+
+You can override with `--cdp-port PORT` on any script.
+
+### Starting the app (Electron)
+
+The launcher builds, syncs to Windows, launches Electron, and auto-connects `playwright-cli` via CDP.
+
+```bash
+.codex/skills/browse-app/scripts/launch-app.sh                         # build if needed + launch + connect
+.codex/skills/browse-app/scripts/launch-app.sh --rebuild                # force rebuild
+```
+
+`playwright-cli` connects directly to the Electron renderer via CDP — no separate browser window. You can interact with the actual Electron UI including WebContentsView tabs.
+
+To reconnect manually (e.g., after daemon dies):
+
+```bash
+.codex/skills/browse-app/scripts/connect-app.sh
+```
+
+### Starting the design system
+
+```bash
+.codex/skills/browse-app/scripts/launch-docs.sh
+```
+
+This starts Vite, swaps `.playwright/cli.config.json` to standalone browser mode (backing up any CDP config), and auto-opens the page in `playwright-cli`. No manual `playwright-cli open` needed.
+
+### Stopping
+
+```bash
+# Close playwright-cli browser:
+playwright-cli close
+
+# For app:
+.codex/skills/browse-app/scripts/teardown-app.sh
+
+# For design system:
+.codex/skills/browse-app/scripts/teardown-docs.sh
+```
+
+`teardown-docs.sh` restores the CDP config backup if one exists, so subsequent `launch-app.sh` / `connect-app.sh` runs work correctly.
+
+## Config Management
+
+`playwright-cli` reads `.playwright/cli.config.json` from the project root to decide how to connect:
+- **App (CDP)**: `connect-app.sh` writes a config with `"cdpEndpoint"` pointing at Electron's debugging port.
+- **Design system (standalone)**: `launch-docs.sh` replaces the config with one that has no `cdpEndpoint`, so `playwright-cli` launches its own Chromium.
+
+The scripts handle backup/restore automatically. If you get a `connectOverCDP: Timeout` error when browsing the design system, the CDP config is active — run `launch-docs.sh` to fix it.
+
+## Connect Workflow
+
+1. Run the appropriate launch script (foreground, not background — these complete in seconds):
+   - **App:** `launch-app.sh` — builds, launches Electron, and auto-connects `playwright-cli` via CDP
+   - **Design system:** `launch-docs.sh` — starts Vite and auto-opens in `playwright-cli`
+2. Run `playwright-cli snapshot` to confirm the page loaded
+3. Run `playwright-cli screenshot` and read the image to confirm visuals
+4. For app, use `playwright-cli tab-list` to see all Electron pages and `playwright-cli tab-select <n>` to switch
+
+## Timeouts
+
+Most scripts should complete in a few seconds. The docs launcher can wait up to about 30 seconds for Vite to become ready; use `timeout: 30000` for it and shorter timeouts for the others. Never run them in the background — you need the output immediately. If a script takes longer than expected, read the output and fix the root cause.
+
+## Tips
+
+- Save screenshots to the scratchpad directory, not the project
+- Always `snapshot` before interacting to get fresh element refs
+- When something looks wrong, take a snapshot too to understand the DOM structure
+- Use `--full-page` on screenshots to capture scrollable content
+
+## Failure handling
+
+- The launch scripts poll for readiness internally and exit on timeout — **do not manually probe CDP or Vite ports**. If the script fails, read its output and act on it directly.
+- If app launch fails, preserve the error and clean up with `teardown-app.sh`. A design-system preview can inspect components, but does not verify the Electron app. Report the app check as unavailable.

--- a/.codex/skills/browse-app/references/development.md
+++ b/.codex/skills/browse-app/references/development.md
@@ -23,7 +23,7 @@ Launch and interact with the running Chiaroscuro app **or the design system webs
 
 ## Browser Interaction via `playwright-cli`
 
-This personal development workflow uses `playwright-cli` via the shell. For isolated verification use the shared controller described in SKILL.md. The CLI manages its own headless Chromium browser with persistent sessions.
+This personal development workflow uses `playwright-cli` via the shell. For isolated verification use the shared controller described in SKILL.md. In app/CDP mode the CLI controls Electron's renderers; only the standalone design-system workflow launches its own Chromium browser.
 
 ### Key commands
 

--- a/.codex/skills/browse-app/scripts/launch-app.sh
+++ b/.codex/skills/browse-app/scripts/launch-app.sh
@@ -9,6 +9,16 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+if [[ "${1:-}" == "--isolated" ]]; then
+  shift
+  cd "$PROJECT_DIR"
+  exec bun run agent:app "$@"
+fi
+if [[ "${1:-}" == "--verify" ]]; then
+  shift
+  cd "$PROJECT_DIR"
+  exec bun run verify:app "$@"
+fi
 REBUILD=false
 CDP_PORT=""
 

--- a/.codex/skills/debug-app/SKILL.md
+++ b/.codex/skills/debug-app/SKILL.md
@@ -1,196 +1,44 @@
 ---
 name: debug-app
-description: Debug and automate the Chiaroscuro browser app via its HTTP debug server. Use when you need to inspect app state, view command/event history, read debug logs, list registered commands, or send commands to the running app. Trigger phrases include "debug the app", "inspect app state", "send a command", "check debug log", "what commands are registered".
+description: Inspect Chiaroscuro feature state, native targets, command/event history and debug logs through its local HTTP server. Use for diagnosing app behavior or preparing verification scenarios.
 ---
 
-# Goal
+# Inspect the browser
 
-Inspect and control the running Chiaroscuro app via the debug HTTP server (`127.0.0.1:19400`).
+Prefer `bun run agent:app` for isolated verification. Its `state`, `targets`,
+`commands`, `event-cursor`, `wait-event` and `setup-command` actions wrap the
+existing HTTP debug server, managing the random port and bearer token privately.
+Read [agent verification](../../../docs/testing/agent-verification.md) for the
+shared launch/restart workflow and evidence bundles.
 
-## Prerequisites
+For an existing personal development app the server binds `127.0.0.1`, defaults
+to port 19400 and can try consecutive ports. Settings > Developer controls it.
+Do not assume a personal app's fixed port is an isolated test instance. Automation
+requires a per-session bearer token. Requests with an Origin header or a Host
+other than localhost/127.0.0.1 are rejected; browser CORS access is not supported.
 
-The app must be running in dev mode (`bun dev`). The debug server is enabled by default in dev. Port defaults to `19400`; if busy, tries up to 10 consecutive ports. Configurable in Settings > Developer.
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /` | Actual port, uptime, providers and available endpoints |
+| `GET /state` | All state; optional `features` and `fields` query filters |
+| `GET /state/{feature}` | One provider, e.g. `tabs`, `sub-tabs`, `targets`, `window` |
+| `GET /commands` | Registered command names |
+| `POST /commands/send` | `{name, payload}`; setup/diagnosis, not UI verification |
+| `GET /history` | Recorded commands, responses, errors, events and registrations |
+| `GET /log` | Bounded application debug log |
+| `DELETE /history`, `DELETE /log` | Clear the respective diagnostic buffer |
 
-## Base URL
+Use `?pretty` for readable JSON. History supports `name` (trailing `*` glob),
+`type`, `since`, `until`, `errors=true`, `payload=true`, `order` and `limit`.
+Logs support `level`, `source`, `since`, `until`, `data=true`, `order` and `limit`.
+Request payloads only when needed, since they can include document data.
 
-```text
-http://127.0.0.1:19400
-```
+Command names are not runtime contracts. Read the feature's `.shared.ts` for
+payload/response types; issue #44's schema migration is still separate. Existing
+HTTP/IPC payload validation is incomplete. Observe results and feature state,
+and never use internal commands as evidence that an edited UI interaction works.
 
-All endpoints accept `?pretty` for formatted JSON output. All responses include CORS headers.
-
-## Endpoints
-
-### GET / — Overview
-
-Returns uptime, port, history count, registered state providers, and endpoint list.
-
-```bash
-curl -s http://127.0.0.1:19400/?pretty
-```
-
-### GET /state — All feature state
-
-Returns state from all registered state providers.
-
-| Param | Description |
-|-------|-------------|
-| `features` | Comma-separated feature names to filter |
-| `fields` | Comma-separated dot-path fields to pluck from each feature's state |
-
-```bash
-# All state
-curl -s 'http://127.0.0.1:19400/state?pretty'
-
-# Specific features
-curl -s 'http://127.0.0.1:19400/state?features=tabs,settings&pretty'
-
-# Pluck specific fields
-curl -s 'http://127.0.0.1:19400/state?features=tabs&fields=activeTab,count&pretty'
-```
-
-### GET /state/{feature} — Single feature state
-
-Returns state for one feature. Returns 404 if feature not found.
-
-| Param | Description |
-|-------|-------------|
-| `fields` | Comma-separated dot-path fields to pluck |
-
-```bash
-curl -s 'http://127.0.0.1:19400/state/tabs?pretty'
-curl -s 'http://127.0.0.1:19400/state/tabs?fields=activeTab&pretty'
-```
-
-### GET /history — Command/event history
-
-Ring buffer of commands sent, events emitted, and handler registrations (max 1000 entries).
-
-| Param | Default | Description |
-|-------|---------|-------------|
-| `limit` | `50` | Max entries to return |
-| `order` | `desc` | Sort order: `asc` or `desc` |
-| `type` | all | Comma-separated: `command`, `event`, `registration` |
-| `name` | all | Exact name or glob with trailing `*` (e.g. `tabs:*`) |
-| `since` | — | Timestamp (ms) or ISO date string |
-| `until` | — | Timestamp (ms) or ISO date string |
-| `errors` | `false` | Set `true` to show only failed commands |
-| `payload` | `false` | Set `true` to include payload/response/error detail |
-
-Entry fields: `id`, `timestamp`, `type`, `name`, and when `payload=true`: `payload`, `response`, `error`, `durationMs`.
-
-```bash
-# Recent 10 commands with payloads
-curl -s 'http://127.0.0.1:19400/history?type=command&limit=10&payload=true&pretty'
-
-# Events matching a prefix
-curl -s 'http://127.0.0.1:19400/history?type=event&name=tabs:*&pretty'
-
-# Failed commands only
-curl -s 'http://127.0.0.1:19400/history?errors=true&payload=true&pretty'
-
-# Oldest first
-curl -s 'http://127.0.0.1:19400/history?order=asc&limit=20&pretty'
-```
-
-### GET /log — Debug log
-
-Structured log ring buffer (max 2000 entries). Entries: `id`, `timestamp`, `level`, `source`, `message`, and optionally `data`.
-
-| Param | Default | Description |
-|-------|---------|-------------|
-| `limit` | `50` | Max entries to return |
-| `order` | `desc` | Sort order: `asc` or `desc` |
-| `level` | all | Min level: `debug`, `info`, `warn`, `error` (filters >=) |
-| `source` | all | Exact source or glob with trailing `*` |
-| `since` | — | Timestamp (ms) or ISO date string |
-| `until` | — | Timestamp (ms) or ISO date string |
-| `data` | `false` | Set `true` to include data field |
-
-```bash
-# Errors and warnings
-curl -s 'http://127.0.0.1:19400/log?level=warn&pretty'
-
-# Logs from a specific source
-curl -s 'http://127.0.0.1:19400/log?source=debug-server&pretty'
-
-# With data payloads
-curl -s 'http://127.0.0.1:19400/log?level=error&data=true&pretty'
-```
-
-### GET /commands — Registered commands
-
-Returns list of all registered command handler names.
-
-```bash
-curl -s 'http://127.0.0.1:19400/commands?pretty'
-```
-
-### POST /commands/send — Send a command
-
-Execute a command on the command bus. Body: `{ "name": "command:name", "payload": <value> }`.
-
-Returns `{ "response": <value> }` on success, 404 if no handler, 500 on error.
-
-```bash
-# Send a command with no payload
-curl -s -X POST http://127.0.0.1:19400/commands/send \
-  -H 'Content-Type: application/json' \
-  -d '{"name": "debug-server:stop"}' | jq
-
-# Send a command with payload
-curl -s -X POST http://127.0.0.1:19400/commands/send \
-  -H 'Content-Type: application/json' \
-  -d '{"name": "tabs:create", "payload": {"url": "https://example.com"}}' | jq
-```
-
-### DELETE /history — Clear history
-
-```bash
-curl -s -X DELETE http://127.0.0.1:19400/history
-```
-
-### DELETE /log — Clear log
-
-```bash
-curl -s -X DELETE http://127.0.0.1:19400/log
-```
-
-## Common workflows
-
-### Check what commands are available, then send one
-
-```bash
-curl -s 'http://127.0.0.1:19400/commands?pretty'
-# Pick a command from the list, then:
-curl -s -X POST http://127.0.0.1:19400/commands/send \
-  -H 'Content-Type: application/json' \
-  -d '{"name": "the:command", "payload": null}'
-```
-
-### Investigate errors
-
-```bash
-# Check for failed commands
-curl -s 'http://127.0.0.1:19400/history?errors=true&payload=true&pretty'
-# Check error logs
-curl -s 'http://127.0.0.1:19400/log?level=error&data=true&pretty'
-```
-
-### Monitor a feature's activity
-
-```bash
-# See all commands/events for a feature
-curl -s 'http://127.0.0.1:19400/history?name=tabs:*&payload=true&pretty'
-# Check its current state
-curl -s 'http://127.0.0.1:19400/state/tabs?pretty'
-```
-
-## Tips
-
-- Use `?pretty` on all GET requests for readable output
-- Pipe through `jq` for filtering/transforming JSON
-- The `name` glob only supports trailing `*` (prefix match), not full glob syntax
-- `level=warn` returns warn AND error entries (filters >=)
-- Payloads/data are excluded by default to keep responses small; opt in with `payload=true` or `data=true`
-- History and log are ring buffers — oldest entries are evicted when full
+Use a history cursor before an action, then a bounded `wait-event` or condition
+assertion. Avoid fixed sleeps and do not retry mutations while waiting for effects.
+When an assertion fails, capture the target inventory, state, history, logs and
+actual visuals before stopping the owned session.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -101,6 +101,10 @@ jobs:
           path: out/
       - name: Run E2E tests
         run: bun run e2e
+      - name: Install desktop verification prerequisites
+        run: sudo apt-get update && sudo apt-get install -y xvfb xauth openbox xcompmgr
+      - name: Verify agent scenarios against composed Electron windows
+        run: bun run verify:app
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
@@ -108,4 +112,32 @@ jobs:
           path: |
             test-results/
             playwright-report/
+          retention-days: 7
+
+  verify-windows:
+    name: Native Windows verification
+    needs: [build, typecheck, lint, test]
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+      - run: bun install --frozen-lockfile
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          path: out/
+      - run: bun run verify:app
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: native-windows-verification
+          path: test-results/verification/
           retention-days: 7

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -118,6 +118,8 @@ jobs:
     name: Native Windows verification
     needs: [build, typecheck, lint, test]
     runs-on: windows-latest
+    permissions:
+      contents: read
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -83,7 +83,7 @@ jobs:
     name: E2E
     needs: [build, typecheck, lint, test]
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
         with:
@@ -118,7 +118,7 @@ jobs:
     name: Native Windows verification
     needs: [build, typecheck, lint, test]
     runs-on: windows-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,16 @@
 # Development
 
 - `bun dev` — start dev server + Electron (Linux/WSLg)
-- `bun run dev:win` — build in WSL, run Electron natively on Windows
+- `bun run dev:win` — explicit HMR workflow: Vite in WSL, Electron on Windows
 - `bun run verify` — run all checks (typecheck + lint + tests)
+
+When the user asks to run, launch, or open the dev browser on Windows for manual
+testing, build the app, deploy the complete build (main, preload, renderer and
+resources) to Windows, and launch Windows Electron using those local files.
+The running browser must remain usable without a WSL dev server or an agent
+session. Use the browse-app skill's Windows deployment instructions. Only use
+the Vite/HMR workflow when the user explicitly requests hot reload. Do not create
+`.dev-server-pid` for the default Windows launch.
 
 The UI must adhere to the design system defined in the companion website found at design-system/.
 

--- a/design-system/src/pages/components/pdf-viewer.mdx
+++ b/design-system/src/pages/components/pdf-viewer.mdx
@@ -6,6 +6,12 @@ title: PDF Viewer
 
 A custom PDF reader that replaces Chromium's built-in viewer. Supports two rendering backends (pdf.js, mupdf) selectable in settings. Includes a user-editable index sidebar, search, zoom, and virtual scrolling for large documents.
 
+Toolbar zoom persists by document identity across application restarts. Verify
+the actual `PdfReaderPage` and `PdfToolbar` with
+`bun run verify:app --grep 'PDF toolbar'`; inspect the composed screenshot and
+trace in `test-results/verification/`. A design-system preview alone does not
+verify persistence or Electron's native view composition.
+
 ---
 
 ## Anatomy

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -9,6 +9,7 @@ Thorough test coverage is a project requirement. Every implemented feature must 
 | [Strategy](./strategy.md) | Test tiers, what to test, what not to test |
 | [Unit & Component Tests](./unit-and-component-tests.md) | Vitest + React Testing Library patterns, mocking |
 | [E2E Tests](./e2e-tests.md) | Playwright + Electron, page object model, fixtures |
+| [Agent Verification](./agent-verification.md) | Isolated launch/restart, target discovery, real input, Windows and failure evidence |
 | [Feature Test Guide](./feature-test-guide.md) | How to write tests for a feature spec, with worked example |
 | [Test Organization](./test-organization.md) | File layout, naming, shared utilities, avoiding conflicts |
 
@@ -31,4 +32,5 @@ bun run verify        # full pipeline (typecheck + lint + test)
 ## Config Files
 
 - `vitest.config.ts` — two projects: `main` (node) and `renderer` (jsdom)
-- `playwright.config.ts` — testDir `./e2e`, 30s timeout, retries on failure
+- `playwright.config.ts` — existing E2E suite, 5s timeout, no retries
+- `playwright.verification.config.ts` — coordinated scenarios including restart/evidence, 30s timeout, no retries

--- a/docs/testing/agent-verification.md
+++ b/docs/testing/agent-verification.md
@@ -53,7 +53,7 @@ bun run verify:app:win --interactive
 
 The controller reports `ready`, a fixture URL, CDP connection URL, artifact
 directory and targets. Send one JSON object per line. Startup build output precedes
-the JSONL responses. Each action returns `passed` or `failed`; an action failure
+the JSONL responses. Each action returns `passed`, `partial` or `failed`; a partial capture or action failure
 also captures evidence and makes the eventual process exit nonzero. EOF, `stop`,
 SIGINT or SIGTERM closes only this controller's Electron instance and fixture site.
 
@@ -124,7 +124,9 @@ WebContentsViews or child windows. Artifacts are named by scope:
 
 Inspect the actual images as well as the assertions. Keep the app unobscured for
 desktop capture. A union of windows spanning displays is currently rejected;
-move the scenario onto one display. Capture errors do not replace the original
+move the scenario onto one display. Startup fits the owned shell onto the display;
+Windows invisible maximized borders are clipped, with crop geometry recorded in
+`*.composed.json`. Capture errors do not replace the original
 test failure. Open traces with `bunx playwright show-trace PATH`.
 
 ## Representative coverage

--- a/docs/testing/agent-verification.md
+++ b/docs/testing/agent-verification.md
@@ -1,0 +1,176 @@
+# Verifying the actual browser
+
+Use the shared `AppSession` in `e2e/automation/session.ts` for ad hoc checks and
+repeatable scenarios. It extends the existing Playwright Electron fixture and HTTP
+debug server. A standalone Chromium or design-system check cannot establish that
+Electron's native views, overlays, focus or process persistence work.
+
+## Run checks from a stopped app
+
+```bash
+bun install --frozen-lockfile
+bun run build
+bun run verify:app                         # representative scenarios, JSON results and artifacts
+bun run verify:app --grep 'PDF toolbar'    # one scenario
+bun run e2e                                # existing fast Ozone headless suite
+bun run verify:app:win                      # from WSL, run natively on Windows
+```
+
+Linux's full suite uses Xvfb at 1920×1080 and Openbox. Install `xvfb`, `xauth` and
+`openbox` and `xcompmgr`; the launcher checks window-manager readiness and saves its log in
+`test-results/desktop.log`. An existing desktop can be used with
+`CHIAROSCURO_HEADED=1 bun run verify:app`. Node and Bun versions follow
+`package.json` and `.node-version`. Electron is downloaded by `setup:electron`.
+
+The WSL launcher requires Windows interop, rsync, Python 3, native Windows Bun
+1.3.11+ and Node 24.15+ (24.20.0 is pinned in CI). It builds locally, syncs into
+`%USERPROFILE%\.chiaroscuro-verification`, installs the frozen lockfile on Windows,
+runs the same Playwright scenarios, and copies evidence back to
+`test-results/windows/`. It also accepts portable `bun.exe` and `node.exe` in that
+directory's `runtime/` folder. It does not install global runtimes or alter device
+policies. If Device Guard rejects Electron, retain the launch log and use a
+permitted native Windows host/CI; that local run is **not verified**.
+
+Every session generates a new temporary profile, isolates both application data
+and Chromium's cookies/cache, redirects downloads away from the normal Desktop,
+and uses OS-assigned inspector, CDP, HTTP debug and fixture ports. No `.env.local`
+or manually launched app is needed. `restart()` closes the full process, saves
+data and relaunches with exactly that profile; `close()` deletes it. Tests may seed
+with `session.command()` and reset by closing and creating a new session. Never
+point tests at a normal user profile. An interrupted/crashed controller can leave
+a temp directory, identifiable by its `chiaroscuro-verify-` prefix and launch log.
+
+## Interactive agent workflow
+
+```bash
+bun run agent:app --help                   # JSON Schema for the controller's input
+bun run agent:app                          # keep stdin open (for example, a tool PTY)
+# Equivalent entry point:
+.codex/skills/browse-app/scripts/launch-app.sh --isolated
+# Native Windows from WSL:
+bun run verify:app:win --interactive
+```
+
+The controller reports `ready`, a fixture URL, CDP connection URL, artifact
+directory and targets. Send one JSON object per line. Startup build output precedes
+the JSONL responses. Each action returns `passed` or `failed`; an action failure
+also captures evidence and makes the eventual process exit nonzero. EOF, `stop`,
+SIGINT or SIGTERM closes only this controller's Electron instance and fixture site.
+
+```json
+{"action":"targets"}
+{"action":"inspect","target":"window:1"}
+{"action":"shortcut","target":"window:1","keyCode":"T","modifiers":["control"]}
+```
+
+Inspect the returned palette target and fill its `#input` with the reported local
+fixture URL, then send `press` with `Enter`. Use the discovered tab target for
+`click`, `fill`, `press`, `scroll`, `upload`, `drag` and `assert-text`. Selectors are
+Playwright selectors, including `role=button[name='Apply']` and CSS. `shortcut`
+uses Electron's `sendInputEvent` because CDP keyboard dispatch does not trigger
+every Electron `before-input-event` shortcut. It exercises the input path, without
+invoking the shortcut's command handler directly.
+
+```json
+{"action":"event-cursor"}
+{"action":"state","feature":"tabs"}
+{"action":"capture","label":"after-change"}
+{"action":"restart"}
+{"action":"stop"}
+```
+
+Use the cursor *before* an action, then `wait-event` with `name` and `after` to
+observe its effect. `assert-text` and event/target waits have deadlines and report
+their last observations. They retry observations, never mutating actions. For
+custom conditions in a scenario use Playwright assertions or `waitUntil`.
+
+`commands` lists registered commands; `setup-command` sends a diagnostic/setup
+command. Feature payload/response types remain in `src/features/*/*.shared.ts`.
+They are **not runtime schemas**: the full shared command-contract migration is
+issue #44 and is not implemented here. The controller's JSON Schema describes
+controller requests, not feature command payloads. Do not infer validation from
+command registration. Internal commands can prepare data but do not verify the UI
+path being changed.
+
+For a CLI-driven browser connection, pass the reported CDP port to the existing
+`connect-app.sh --cdp-port PORT` and use `playwright-cli` while the owning
+controller remains running. Teardown belongs to the controller (`stop`), not the
+personal dev launcher. After restart, reconnect and rediscover targets.
+
+## Targets and evidence
+
+`GET /state/targets` reports logical tab IDs, native window and WebContents IDs,
+CDP IDs, URLs, kind, parent relationships, focus, visibility and geometry. Window
+bounds use screen coordinates; tab bounds are relative to their owning window.
+Built-in pages share the shell's CDP target and retain their logical tab ID.
+Sub-tabs point at their parent tab; palette/frame windows point at their parent
+window. Native IDs change after restart. Tabs retain their persisted IDs. Select
+by kind/relationship/ID, not an index in the list or a URL that multiple tabs share.
+
+`inspect` includes an ARIA snapshot, DOM focus, DOM dialog/menu/listbox surfaces
+and active Web Animations. Plain renderer screenshots do not include overlaid
+WebContentsViews or child windows. Artifacts are named by scope:
+
+| Artifact | Meaning |
+| --- | --- |
+| `*.renderer.png`, `*.inspection.json` | One renderer and its accessibility/focus data |
+| `*.composed.png` | OS screen capture cropped to the visible application's window bounds, including native views/child windows |
+| `*.frames.json`, `*.frame-*.png` | One renderer's filmstrip with compositor timestamps; up to 90 frames |
+| `trace-N.zip` | Playwright actions, DOM snapshots and screenshots for process generation N |
+| `*.state.json`, `*.targets.json` | Feature state, commands/results, event history, logs and runtime versions |
+| `journal.json`, `*.last-targets.json` | Bounded controller/console/network journal and last inventory, including after a crash |
+| `result.json`, `results.json` | Per-test and suite status, failures and rerun information |
+| `*.evidence.json` | Capture errors/unsupported capabilities; missing evidence is never a successful capture |
+
+Inspect the actual images as well as the assertions. Keep the app unobscured for
+desktop capture. A union of windows spanning displays is currently rejected;
+move the scenario onto one display. Capture errors do not replace the original
+test failure. Open traces with `bunx playwright show-trace PATH`.
+
+## Representative coverage
+
+`e2e/scenarios/verification.spec.ts` runs five scenarios using real UI navigation:
+
+- Palette input → local tab → sub-tab input/focus → close overlay → native popup
+  input → return focus to parent, with layer and composed screenshots.
+- Local PDF → toolbar zoom → complete process restart → restored PDF and zoom.
+  This exposed and fixed renderer-only zoom persistence; zoom is now saved by
+  document filename/content hash and restored when fetching the PDF.
+- File input, scrolling, clipboard copy (restoring prior text), controlled denied
+  notification permission, downloaded bytes, pointer sidebar resizing and native
+  maximize control. Permission setup is seeded; this does not claim to test the
+  native permission prompt itself.
+- Native pointer drag reorders real sidebar tabs and records animation frames.
+- An intentional missing-target assertion writes a failed result and coherent
+  evidence bundle; the outer test succeeds only if the failure evidence exists.
+
+The fixture site serves local HTML, a generated one-page PDF, a controlled
+download and a deliberate HTTP 503 route. No external websites are needed for
+these scenarios. Add fixtures/routes alongside `site.ts`, use page objects for
+interaction and `test.step` for longer workflows. Choose checks based on the
+changed behavior, not solely on whether the app still responds.
+
+## Limits and CI
+
+Ozone headless has no desktop compositor and Electron 44's native popup path
+can terminate its process. The existing fast suite uses Ozone; the broader suite
+uses Xvfb + a window manager or native Windows. Do not report headless renderer
+screenshots as composed visual evidence. Native OS file pickers, external-app
+drag/drop, system permission menus, touch/IME/accessibility assistive technology
+and global OS hotkey conflicts remain gaps. `setInputFiles` verifies the file
+input integration, not the OS picker. Filmstrips help inspect timing but are not
+a fixed-frame-rate desktop video or a perceptual animation assertion. Separate
+independent main browser windows are not implemented by the application;
+multi-window coverage here uses actual palette, sub-tab and popup windows.
+
+The debug server binds loopback, rejects Origin-bearing requests and unexpected
+Host values, and requires an unlogged per-session bearer token in automation.
+Test hooks require `NODE_ENV=test`, `CHIAROSCURO_AUTOMATION=1` and an absolute
+isolated `DATA_DIR`. HTTP server startup uses a random port in this mode.
+
+PR CI runs both the existing E2E suite and these scenarios under Linux, plus a
+native Windows job. Both upload evidence even on failure. Unit checks include
+E2E/controller TypeScript compilation. Use the design system for component
+appearance and interactions; retain Electron scenarios for process boundaries,
+native layers and persistence. The PDF component documentation links to its
+restart scenario; design-system demos do not replace it.

--- a/docs/testing/agent-verification.md
+++ b/docs/testing/agent-verification.md
@@ -154,6 +154,39 @@ changed behavior, not solely on whether the app still responds.
 
 ## Limits and CI
 
+### Native title-bar hit testing
+
+For the address-bar icon click report in #51, run the optional diagnostic:
+
+```bash
+bun run verify:app:win --address-bar
+bun run verify:app:win --address-bar --maximized
+# Or inside a prepared native Windows checkout:
+bun run diagnose:address-bar
+```
+
+This uses the same isolated `AppSession` and local fixture site. It compares
+Playwright/CDP clicks with the Windows desktop pointer at each button's icon
+center and left padding, with Reload as a positive control. The Windows helper
+checks the foreground window and window under the pointer before clicking,
+accounts for display scale and renderer zoom, and records `WM_NCHITTEST` results:
+`HTCLIENT` (1) versus `HTCAPTION` (2). A caption region can consume mouse input
+before the renderer receives it; a successful CDP click alone cannot verify this
+path. See [Electron's draggable-region behavior](https://github.com/electron/electron/blob/main/docs/tutorial/custom-window-interactions.md)
+and [Windows hit-test results](https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-nchittest).
+
+Results, hover screenshots, geometry, native input records and the standard
+evidence bundle are saved under `test-results/address-bar/`, mirrored to
+`test-results/windows/address-bar/` by the WSL launcher. The diagnostic restores
+clipboard text and cleans up its own profile. It distinguishes the exact report
+(blocked icons with working padding), a broader failure (padding also blocked),
+no reproduction, and a failed positive control. Missing desktop screenshots are
+reported as partial evidence with a nonzero exit; renderer screenshots do not
+establish desktop composition. This is a diagnostic, not a passing regression
+test or a fix for #51, and it does not run in the regular CI suite.
+
+### Remaining gaps
+
 Ozone headless has no desktop compositor and Electron 44's native popup path
 can terminate its process. The existing fast suite uses Ozone; the broader suite
 uses Xvfb + a window manager or native Windows. Do not report headless renderer

--- a/docs/testing/e2e-tests.md
+++ b/docs/testing/e2e-tests.md
@@ -1,340 +1,55 @@
-# E2E Tests
+# Electron E2E tests
 
-## Overview
+The runnable source of truth is `e2e/fixtures/electron-app.ts`, which creates an
+`AppSession` from `e2e/automation/session.ts`. It launches the built Electron app,
+waits for the shell and feature startup, and cleans up the isolated data and
+Chromium profile in a finally block. Tests receive `appSession`, `electronApp` and
+`shellPage`; `e2e/fixtures/test.ts` composes the feature page objects.
 
-E2E tests use Playwright's Electron API to launch the real app and drive it through primary user flows. They cover the full stack: UI → IPC → main process → platform → data store.
+Run `bun run build && bun run e2e`. The existing suite uses Ozone headless on Linux,
+with an explicit 1920×1080 virtual screen, 5s test deadlines, no retries and 2 CI /
+4 local workers. The fixture has a separate bounded lifecycle/evidence timeout.
+Each worker's profile and debug ports are isolated. `bun run setup:electron`
+prepares Electron before parallel workers start.
 
-## Configuration
+For coordinated scenarios, native Windows, composed screenshots, restart and
+failure diagnostics, read [Agent Verification](./agent-verification.md). Run
+`bun run verify:app`; this uses the same session under Linux Xvfb/Openbox/xcompmgr or native
+Windows. Its 30s scenario deadline includes restart and evidence collection and
+does not raise deadlines for the existing tests.
 
-`playwright.config.ts`:
-- Test directory: `./e2e`
-- Timeout: 30 seconds per test
-- Retries: 2 on CI, 0 locally (trace recorded on first retry)
+## Page objects and assertions
 
-## Directory Structure
-
-```text
-e2e/
-  fixtures/
-    electron-app.ts           # Electron launch fixture
-    test.ts                   # Extended test with page objects
-  pages/
-    sidebar.page.ts           # Sidebar page object
-    command-palette.page.ts   # Command palette page object
-    window-chrome.page.ts     # Window chrome page object
-    ...                       # one per feature area
-  helpers/
-    ipc.ts                    # Main-process IPC helpers
-  tests/
-    sidebar/
-      tab-management.spec.ts
-      workspace-switching.spec.ts
-      drag-reorder.spec.ts
-    tabs/
-      create-close.spec.ts
-      bookmark-toggle.spec.ts
-    command-palette/
-      navigation.spec.ts
-    ...                       # one dir per feature
-```
-
-## Page Object Model
-
-Each page object encapsulates locators and high-level actions for a feature area. Since Chiaroscuro is a single-window app with sub-regions, page objects represent **feature regions** not separate pages.
-
-### Rules
-
-1. **Locators are properties, actions are methods.** Locators defined in constructor, never in test files.
-2. **Page objects never make assertions.** Tests assert, page objects interact.
-3. **Page objects return data for assertions** (e.g. `getTabTitles(): Promise<string[]>`).
-4. **Compose, don't inherit.** Multiple page objects can wrap the same `Page` — use composition.
-5. **Name methods from the user's perspective** (`switchWorkspace`, `closeTab`, not `clickElement`).
-
-### Example
+Keep reusable locators/actions in `e2e/pages/`. Compose page objects around a
+Playwright `Page`; tests assert observable behavior. Prefer roles and labels,
+using stable tab IDs for repeated rows. For native WebContentsViews, discover the
+target with `appSession.targets()` and obtain its page using
+`appSession.page(target)`. A built-in page shares the shell target. Never assume
+`firstWindow()` or one renderer's screenshot represents all native layers.
 
 ```ts
-// e2e/pages/sidebar.page.ts
-import type { Page, Locator } from "@playwright/test";
+import { expect, test } from "../../fixtures/electron-app";
 
-export class SidebarPage {
-  readonly page: Page;
-  readonly sidebar: Locator;
-  readonly tabList: Locator;
-  readonly activeTab: Locator;
-
-  constructor(page: Page) {
-    this.page = page;
-    this.sidebar = page.locator("[data-testid='sidebar']");
-    this.tabList = this.sidebar.locator("[data-testid='tab-list']");
-    this.activeTab = this.tabList.locator("[data-state='active']");
-  }
-
-  async switchWorkspace(name: string) {
-    await this.sidebar
-      .locator(`[aria-label="Switch to ${name}"]`)
-      .click();
-  }
-
-  async getTabCount(): Promise<number> {
-    return this.tabList.locator("[data-tab-id]").count();
-  }
-
-  async clickTab(title: string) {
-    await this.tabList.locator("[data-tab-id]", { hasText: title }).click();
-  }
-
-  async closeTab(title: string) {
-    const tab = this.tabList.locator("[data-tab-id]", { hasText: title });
-    await tab.hover();
-    await tab.locator("[aria-label='Close tab']").click();
-  }
-
-  async dragTab(fromTitle: string, toTitle: string) {
-    const from = this.tabList.locator("[data-tab-id]", { hasText: fromTitle });
-    const to = this.tabList.locator("[data-tab-id]", { hasText: toTitle });
-    await from.dragTo(to);
-  }
-
-  async getTabTitles(): Promise<string[]> {
-    return this.tabList
-      .locator("[data-tab-id] [data-testid='tab-title']")
-      .allTextContents();
-  }
-}
-```
-
-### Command Palette Page Object
-
-```ts
-// e2e/pages/command-palette.page.ts
-import type { Page, Locator } from "@playwright/test";
-
-export class CommandPalettePage {
-  readonly page: Page;
-  readonly overlay: Locator;
-  readonly input: Locator;
-  readonly results: Locator;
-
-  constructor(page: Page) {
-    this.page = page;
-    this.overlay = page.locator("[data-testid='command-palette']");
-    this.input = this.overlay.locator("input");
-    this.results = this.overlay.locator("[data-testid='suggestion-list']");
-  }
-
-  async open() {
-    await this.page.keyboard.press("Control+k");
-    await this.overlay.waitFor({ state: "visible" });
-  }
-
-  async close() {
-    await this.page.keyboard.press("Escape");
-    await this.overlay.waitFor({ state: "hidden" });
-  }
-
-  async search(query: string) {
-    await this.input.fill(query);
-  }
-
-  async selectResult(index: number) {
-    await this.results.locator(`[data-index="${index}"]`).click();
-  }
-}
-```
-
-## Electron Fixture
-
-```ts
-// e2e/fixtures/electron-app.ts
-import { _electron as electron, type ElectronApplication, type Page } from "playwright";
-import { test as base } from "@playwright/test";
-
-type ElectronFixtures = {
-  electronApp: ElectronApplication;
-  shellPage: Page;
-};
-
-export const test = base.extend<ElectronFixtures>({
-  electronApp: async ({}, use) => {
-    const app = await electron.launch({
-      args: ["./out/main/index.js"],
-      env: {
-        ...process.env,
-        NODE_ENV: "test",
-        ELECTRON_DISABLE_GPU: "1",
-      },
-    });
-    await use(app);
-    await app.close();
-  },
-
-  shellPage: async ({ electronApp }, use) => {
-    const page = await electronApp.firstWindow();
-    await page.waitForSelector("[data-testid='shell-ready']");
-    await use(page);
-  },
-});
-
-export { expect } from "@playwright/test";
-```
-
-## Composing Fixtures with Page Objects
-
-```ts
-// e2e/fixtures/test.ts
-import { test as electronTest } from "./electron-app";
-import { SidebarPage } from "../pages/sidebar.page";
-import { CommandPalettePage } from "../pages/command-palette.page";
-
-type AppFixtures = {
-  sidebarPage: SidebarPage;
-  commandPalettePage: CommandPalettePage;
-};
-
-export const test = electronTest.extend<AppFixtures>({
-  sidebarPage: async ({ shellPage }, use) => {
-    await use(new SidebarPage(shellPage));
-  },
-  commandPalettePage: async ({ shellPage }, use) => {
-    await use(new CommandPalettePage(shellPage));
-  },
-});
-
-export { expect } from "@playwright/test";
-```
-
-## Writing E2E Tests
-
-```ts
-// e2e/tests/sidebar/tab-management.spec.ts
-import { test, expect } from "../../fixtures/test";
-
-test.describe("tab management", () => {
-  test("opens new tab via command palette", async ({ sidebarPage, commandPalettePage }) => {
-    const before = await sidebarPage.getTabCount();
-    await commandPalettePage.open();
-    await commandPalettePage.search("https://example.com");
-    await commandPalettePage.page.keyboard.press("Enter");
-
-    await expect(async () => {
-      expect(await sidebarPage.getTabCount()).toBe(before + 1);
-    }).toPass({ timeout: 5000 });
-  });
-
-  // Note: these tests assume tabs created in beforeEach or prior tests.
-  // In real test files, use a beforeEach fixture to seed required tabs.
-
-  test("closes tab via close button", async ({ sidebarPage }) => {
-    await sidebarPage.closeTab("Example");
-    await expect(async () => {
-      const titles = await sidebarPage.getTabTitles();
-      expect(titles).not.toContain("Example");
-    }).toPass({ timeout: 3000 });
-  });
-
-  test("reorders tabs via drag", async ({ sidebarPage }) => {
-    await sidebarPage.dragTab("Tab A", "Tab C");
-    const order = await sidebarPage.getTabTitles();
-    expect(order.indexOf("Tab A")).toBeGreaterThan(order.indexOf("Tab C"));
-  });
+test("sidebar is available", async ({ shellPage }) => {
+  await expect(shellPage.getByRole("navigation", { name: "Sidebar" })).toBeVisible();
 });
 ```
 
-## Electron-Specific Concerns
+Use real keyboard/pointer input for the path being verified. Scenario setup can
+use `appSession.command(name, payload)` or the existing IPC helper, but it is not
+proof that a button or shortcut works. Electron shortcuts sometimes need
+`webContents.sendInputEvent` instead of CDP keyboard dispatch; see
+`VerificationPage.navigate` for the actual palette input path.
 
-### IPC Evaluation
+Use Playwright assertions, `waitUntil`, and history cursors/event waits for
+conditions. Do not use fixed sleeps or retry mutating actions. The fixture saves
+traces for each process generation and captures state, target inventory,
+accessibility, console/network errors and available screenshots on failure.
+`result.json` includes the error and a rerun command.
 
-Execute code in the main process from tests:
+## CI
 
-```ts
-// e2e/helpers/ipc.ts
-import type { ElectronApplication } from "playwright";
-
-export async function sendCommand(
-  app: ElectronApplication,
-  name: string,
-  payload: unknown,
-): Promise<unknown> {
-  return app.evaluate(
-    async (_electron, { name, payload }) => {
-      const hooks = (globalThis as any).__testHooks;
-      if (!hooks) throw new Error("Test hooks not available — is NODE_ENV=test?");
-      return hooks.commandBus.send(name, payload);
-    },
-    { name, payload },
-  );
-}
-```
-
-Expose test hooks conditionally in main process:
-
-```ts
-// src/main/index.ts
-if (process.env.NODE_ENV === "test") {
-  (global as any).__testHooks = { commandBus, eventBus, store };
-}
-```
-
-### WebContentsView
-
-Playwright's `_electron` API exposes `BrowserWindow` instances as pages but does not automatically expose `WebContentsView` children. Options:
-
-1. Use `app.evaluate()` to drive tab content from the main process
-2. Use CDP directly for tab content testing
-3. Test tab content behavior through commands/events
-
-### Multiple Windows
-
-```ts
-test("opens settings in new window", async ({ electronApp, commandPalettePage }) => {
-  const windowPromise = electronApp.waitForEvent("window");
-  await commandPalettePage.open();
-  await commandPalettePage.search("Settings");
-  await commandPalettePage.page.keyboard.press("Enter");
-  const settingsPage = await windowPromise;
-  await expect(settingsPage.locator("h1")).toHaveText("Settings");
-});
-```
-
-### Test Data Isolation
-
-For E2E, use a temp data directory per test run:
-
-```ts
-electronApp: async ({}, use) => {
-  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "chiaroscuro-test-"));
-  const app = await electron.launch({
-    args: ["./out/main/index.js"],
-    env: { ...process.env, NODE_ENV: "test", DATA_DIR: tmpDir },
-  });
-  try {
-    await use(app);
-  } finally {
-    await app.close().catch(() => {});
-    await fs.rm(tmpDir, { recursive: true, force: true });
-  }
-},
-```
-
-## CI/CD
-
-Electron tests must run serially (`workers: 1`) since they share a single app instance.
-
-```ts
-// playwright.config.ts
-export default defineConfig({
-  workers: 1,
-  retries: process.env.CI ? 2 : 0,
-  reporter: process.env.CI
-    ? [["github"], ["html", { open: "never" }]]
-    : [["list"]],
-  use: {
-    trace: "on-first-retry",
-    screenshot: "only-on-failure",
-    video: "on-first-retry",
-  },
-});
-```
-
-On Linux, Electron runs with `--ozone-platform=headless` (set automatically in the
-test fixture), so no display server or `xvfb-run` wrapper is needed.
+PR CI builds once, runs the existing E2E suite and the deterministic verification
+scenarios on Linux, and runs a separate native Windows verification job. Both
+upload artifacts even after failures. Component previews in the design system
+complement this coverage but cannot replace native Electron tests.

--- a/e2e/automation/cli.ts
+++ b/e2e/automation/cli.ts
@@ -65,6 +65,8 @@ if (process.argv.includes("--help")) {
   const session = new AppSession(path.resolve("test-results", `interactive-${Date.now()}`));
   const site = await startSite();
   const lines = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+  // Install the iterator before launching Electron so piped input/EOF is buffered during startup.
+  const input = lines[Symbol.asyncIterator]();
   process.once("SIGINT", () => lines.close());
   process.once("SIGTERM", () => lines.close());
   try {
@@ -78,7 +80,7 @@ if (process.argv.includes("--help")) {
         targets: await session.targets(),
       }),
     );
-    for await (const line of lines) {
+    for await (const line of input) {
       if (!line.trim()) continue;
       try {
         const request = requestSchema.parse(JSON.parse(line));
@@ -165,7 +167,7 @@ if (process.argv.includes("--help")) {
               result = await session.command(request.name, request.payload);
               break;
             case "capture":
-              await session.capture(request.label);
+              result = await session.capture(request.label);
               break;
             case "restart":
               await session.restart();
@@ -173,7 +175,16 @@ if (process.argv.includes("--help")) {
               break;
           }
         }
-        console.log(JSON.stringify({ status: "passed", action: request.action, result }));
+        const partial =
+          request.action === "capture" && (result as { status: string }).status === "partial";
+        if (partial) process.exitCode = 1;
+        console.log(
+          JSON.stringify({
+            status: partial ? "partial" : "passed",
+            action: request.action,
+            result,
+          }),
+        );
       } catch (error) {
         process.exitCode = 1;
         await session.capture("action-failure");

--- a/e2e/automation/cli.ts
+++ b/e2e/automation/cli.ts
@@ -1,0 +1,194 @@
+import path from "node:path";
+import readline from "node:readline";
+import { z } from "zod";
+import { AppSession } from "./session";
+import { startSite } from "./site";
+import { waitUntil } from "./wait";
+
+const target = z.string().describe("Stable ID from targets, e.g. window:1 or tab:UUID");
+const locator = {
+  target,
+  selector: z.string().describe("Playwright selector, e.g. role=button[name='Zoom in']"),
+};
+const requestSchema = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("targets") }),
+  z.object({ action: z.literal("inspect"), target }),
+  z.object({ action: z.literal("click"), ...locator }),
+  z.object({ action: z.literal("fill"), ...locator, value: z.string() }),
+  z.object({ action: z.literal("press"), target, key: z.string() }),
+  z.object({
+    action: z.literal("shortcut"),
+    target,
+    keyCode: z.string(),
+    modifiers: z.array(z.enum(["control", "shift", "alt", "meta"])).default([]),
+  }),
+  z.object({ action: z.literal("scroll"), target, x: z.number(), y: z.number() }),
+  z.object({ action: z.literal("drag"), ...locator, destination: z.string() }),
+  z.object({ action: z.literal("upload"), ...locator, files: z.array(z.string()) }),
+  z.object({
+    action: z.literal("assert-text"),
+    ...locator,
+    text: z.string(),
+    timeoutMs: z.number().int().min(1).max(30_000).default(5_000),
+  }),
+  z.object({ action: z.literal("event-cursor") }),
+  z.object({ action: z.literal("wait-event"), name: z.string(), after: z.number().int().min(0) }),
+  z.object({ action: z.literal("state"), feature: z.string().optional() }),
+  z.object({ action: z.literal("commands") }),
+  z.object({
+    action: z.literal("setup-command"),
+    name: z.string(),
+    payload: z.unknown().optional(),
+  }),
+  z.object({ action: z.literal("capture"), label: z.string().regex(/^[a-zA-Z0-9_-]+$/) }),
+  z.object({ action: z.literal("restart") }),
+  z.object({ action: z.literal("stop") }),
+]);
+
+if (process.argv.includes("--help")) {
+  console.log(
+    JSON.stringify(
+      {
+        description:
+          "JSONL stdin/stdout controller using the shared Playwright Electron fixture. Starts an isolated app and local fixture site. EOF or stop cleans up.",
+        requests: z.toJSONSchema(requestSchema),
+        examples: [
+          { action: "targets" },
+          { action: "shortcut", target: "window:1", keyCode: "T", modifiers: ["control"] },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+} else {
+  const session = new AppSession(path.resolve("test-results", `interactive-${Date.now()}`));
+  const site = await startSite();
+  const lines = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+  process.once("SIGINT", () => lines.close());
+  process.once("SIGTERM", () => lines.close());
+  try {
+    await session.launch();
+    console.log(
+      JSON.stringify({
+        status: "ready",
+        artifactDir: session.artifactDir,
+        fixtureUrl: site.url,
+        connection: await session.connection(),
+        targets: await session.targets(),
+      }),
+    );
+    for await (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const request = requestSchema.parse(JSON.parse(line));
+        session.record("action", request);
+        let result: unknown;
+        if (request.action === "stop") break;
+        if ("target" in request) {
+          const nativeTarget = await session.target((target) => target.id === request.target);
+          const page = await session.page(nativeTarget);
+          switch (request.action) {
+            case "inspect":
+              result = await session.inspect(nativeTarget);
+              break;
+            case "click":
+              await page.locator(request.selector).click();
+              break;
+            case "fill":
+              await page.locator(request.selector).fill(request.value);
+              break;
+            case "press":
+              await page.keyboard.press(request.key);
+              break;
+            case "shortcut":
+              await session.app.evaluate(
+                ({ webContents }, input) => {
+                  const wc = webContents.fromId(input.id);
+                  if (!wc) throw new Error("Target closed");
+                  wc.sendInputEvent({
+                    type: "keyDown",
+                    keyCode: input.keyCode,
+                    modifiers: input.modifiers,
+                  });
+                  wc.sendInputEvent({
+                    type: "keyUp",
+                    keyCode: input.keyCode,
+                    modifiers: input.modifiers,
+                  });
+                },
+                {
+                  id: nativeTarget.webContentsId,
+                  keyCode: request.keyCode,
+                  modifiers: request.modifiers,
+                },
+              );
+              break;
+            case "scroll":
+              await page.mouse.wheel(request.x, request.y);
+              break;
+            case "drag":
+              await page.locator(request.selector).dragTo(page.locator(request.destination));
+              break;
+            case "upload":
+              await page.locator(request.selector).setInputFiles(request.files);
+              break;
+            case "assert-text":
+              result = await waitUntil(
+                `text ${request.text}`,
+                () => page.locator(request.selector).textContent({ timeout: request.timeoutMs }),
+                (text) => text === request.text,
+                request.timeoutMs,
+              );
+              break;
+          }
+        } else {
+          switch (request.action) {
+            case "targets":
+              result = await session.targets();
+              break;
+            case "event-cursor":
+              result = await session.eventCursor();
+              break;
+            case "wait-event":
+              result = await session.waitForEvent(request.name, request.after);
+              break;
+            case "state":
+              result = await session.debug(
+                request.feature ? `/state/${encodeURIComponent(request.feature)}` : "/state",
+              );
+              break;
+            case "commands":
+              result = await session.debug("/commands");
+              break;
+            case "setup-command":
+              result = await session.command(request.name, request.payload);
+              break;
+            case "capture":
+              await session.capture(request.label);
+              break;
+            case "restart":
+              await session.restart();
+              result = await session.targets();
+              break;
+          }
+        }
+        console.log(JSON.stringify({ status: "passed", action: request.action, result }));
+      } catch (error) {
+        process.exitCode = 1;
+        await session.capture("action-failure");
+        console.log(
+          JSON.stringify({
+            status: "failed",
+            error: error instanceof z.ZodError ? error.issues : String(error),
+            artifactDir: session.artifactDir,
+          }),
+        );
+      }
+    }
+  } finally {
+    lines.close();
+    await session.close();
+    await site.close();
+  }
+}

--- a/e2e/automation/cli.ts
+++ b/e2e/automation/cli.ts
@@ -63,6 +63,7 @@ if (process.argv.includes("--help")) {
   );
 } else {
   const session = new AppSession(path.resolve("test-results", `interactive-${Date.now()}`));
+  let failureCount = 0;
   const site = await startSite();
   const lines = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
   // Install the iterator before launching Electron so piped input/EOF is buffered during startup.
@@ -187,11 +188,19 @@ if (process.argv.includes("--help")) {
         );
       } catch (error) {
         process.exitCode = 1;
-        await session.capture("action-failure");
+        const evidenceLabel = `action-failure-${++failureCount}`;
+        let captureError: string | undefined;
+        try {
+          await session.capture(evidenceLabel);
+        } catch (problem) {
+          captureError = String(problem);
+        }
         console.log(
           JSON.stringify({
             status: "failed",
             error: error instanceof z.ZodError ? error.issues : String(error),
+            evidenceLabel,
+            captureError,
             artifactDir: session.artifactDir,
           }),
         );

--- a/e2e/automation/run.ts
+++ b/e2e/automation/run.ts
@@ -1,0 +1,37 @@
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const args = [
+  require.resolve("@playwright/test/cli"),
+  "test",
+  "--config",
+  "playwright.verification.config.ts",
+  ...process.argv.slice(2),
+];
+// The full suite needs a window manager for focus, native controls and popup windows.
+const linux = process.platform === "linux" && process.env.CHIAROSCURO_HEADED !== "1";
+const child = linux
+  ? spawn(
+      "xvfb-run",
+      [
+        "-a",
+        "-s",
+        "-screen 0 1920x1080x24",
+        "bash",
+        "scripts/verification-desktop.sh",
+        "node",
+        ...args,
+      ],
+      { stdio: "inherit", env: { ...process.env, CHIAROSCURO_HEADED: "1" } },
+    )
+  : spawn("node", args, { stdio: "inherit" });
+child.on("error", (error) => {
+  console.error(
+    `Cannot start verification: ${error.message}. Linux requires xvfb, xauth, openbox and xcompmgr; Windows requires Node and Electron. See docs/testing/agent-verification.md.`,
+  );
+  process.exitCode = 1;
+});
+child.on("exit", (code) => {
+  process.exitCode = code ?? 1;
+});

--- a/e2e/automation/session.ts
+++ b/e2e/automation/session.ts
@@ -109,7 +109,8 @@ export class AppSession {
       );
       this.debugUrl = `http://127.0.0.1:${port}`;
       const shellTarget = await this.target((target) => target.kind === "shell");
-      this.shell = await this.page(shellTarget);
+      // Cold native renderer startup can outlast an ordinary interaction deadline.
+      this.shell = await this.page(shellTarget, 15_000);
       this.record(
         "setup-window",
         await this.app.evaluate(({ BrowserWindow, screen }, id) => {
@@ -202,7 +203,7 @@ export class AppSession {
     return target;
   }
 
-  async page(target: DebugTarget): Promise<Page> {
+  async page(target: DebugTarget, timeoutMs = 5_000): Promise<Page> {
     const cached = this.pages.get(target.cdpTargetId);
     if (cached && !cached.isClosed()) return cached;
     const page = await waitUntil(
@@ -214,6 +215,8 @@ export class AppSession {
           try {
             const { targetInfo } = await cdp.send("Target.getTargetInfo");
             this.pages.set(targetInfo.targetId, page);
+            this.record("page-discovered", { id: targetInfo.targetId, url: page.url() });
+            if (targetInfo.targetId === target.cdpTargetId) return page;
           } finally {
             await cdp.detach();
           }
@@ -221,6 +224,7 @@ export class AppSession {
         return this.pages.get(target.cdpTargetId);
       },
       (page) => !!page,
+      timeoutMs,
     );
     if (!page) throw new Error(`No page for ${target.id}`);
     return page;

--- a/e2e/automation/session.ts
+++ b/e2e/automation/session.ts
@@ -108,7 +108,27 @@ export class AppSession {
         15_000,
       );
       this.debugUrl = `http://127.0.0.1:${port}`;
-      this.shell = await this.page(await this.target((target) => target.kind === "shell"));
+      const shellTarget = await this.target((target) => target.kind === "shell");
+      this.shell = await this.page(shellTarget);
+      this.record(
+        "setup-window",
+        await this.app.evaluate(({ BrowserWindow, screen }, id) => {
+          const win = BrowserWindow.fromId(id);
+          if (!win) throw new Error("Shell window disappeared");
+          const before = win.getBounds();
+          const area = screen.getDisplayMatching(before).workArea;
+          const width = Math.min(before.width, area.width);
+          const height = Math.min(before.height, area.height);
+          const bounds = {
+            width,
+            height,
+            x: Math.max(area.x, Math.min(before.x, area.x + area.width - width)),
+            y: Math.max(area.y, Math.min(before.y, area.y + area.height - height)),
+          };
+          if (!win.isMaximized()) win.setBounds(bounds);
+          return { before, after: win.getBounds() };
+        }, shellTarget.windowId ?? 0),
+      );
       await this.shell
         .locator("[data-testid='shell-ready']")
         .waitFor({ state: "attached", timeout: 15_000 });
@@ -126,12 +146,15 @@ export class AppSession {
   }
 
   async environment() {
-    return this.app.evaluate(({ app }) => ({
+    return this.app.evaluate(({ app, screen }) => ({
       versions: process.versions,
       platform: process.platform,
       pid: process.pid,
       userData: app.getPath("userData"),
       argv: process.argv,
+      displays: screen
+        .getAllDisplays()
+        .map(({ id, bounds, workArea, scaleFactor }) => ({ id, bounds, workArea, scaleFactor })),
     }));
   }
 
@@ -308,6 +331,7 @@ export class AppSession {
         (candidate) => candidate.isVisible() && !candidate.isMinimized(),
       );
       const rectangles = visibleWindows.map((candidate) => candidate.getBounds());
+      if (!rectangles.length) throw new Error("No visible application windows");
       const left = Math.min(...rectangles.map((rect) => rect.x));
       const top = Math.min(...rectangles.map((rect) => rect.y));
       const bounds = {
@@ -317,13 +341,26 @@ export class AppSession {
         height: Math.max(...rectangles.map((rect) => rect.y + rect.height)) - top,
       };
       const display = screen.getDisplayMatching(bounds);
-      if (
-        bounds.x < display.bounds.x ||
-        bounds.y < display.bounds.y ||
-        bounds.x + bounds.width > display.bounds.x + display.bounds.width ||
-        bounds.y + bounds.height > display.bounds.y + display.bounds.height
-      )
+      const intersectingDisplays = screen
+        .getAllDisplays()
+        .filter(
+          ({ bounds: other }) =>
+            bounds.x < other.x + other.width &&
+            bounds.x + bounds.width > other.x &&
+            bounds.y < other.y + other.height &&
+            bounds.y + bounds.height > other.y,
+        );
+      if (intersectingDisplays.length > 1)
         throw new Error("Window spans displays; move it onto one display before capture");
+      // Maximized Windows windows include invisible borders outside the monitor.
+      const crop = {
+        x: Math.max(bounds.x, display.bounds.x),
+        y: Math.max(bounds.y, display.bounds.y),
+        right: Math.min(bounds.x + bounds.width, display.bounds.x + display.bounds.width),
+        bottom: Math.min(bounds.y + bounds.height, display.bounds.y + display.bounds.height),
+      };
+      if (crop.right <= crop.x || crop.bottom <= crop.y)
+        throw new Error("Application is outside the captured display");
       const sources = await desktopCapturer.getSources({
         types: ["screen"],
         thumbnailSize: {
@@ -337,22 +374,25 @@ export class AppSession {
       const size = source.thumbnail.getSize();
       const scaleX = size.width / display.size.width;
       const scaleY = size.height / display.size.height;
-      return source.thumbnail
+      const png = source.thumbnail
         .crop({
-          x: Math.round((bounds.x - display.bounds.x) * scaleX),
-          y: Math.round((bounds.y - display.bounds.y) * scaleY),
-          width: Math.round(bounds.width * scaleX),
-          height: Math.round(bounds.height * scaleY),
+          x: Math.round((crop.x - display.bounds.x) * scaleX),
+          y: Math.round((crop.y - display.bounds.y) * scaleY),
+          width: Math.round((crop.right - crop.x) * scaleX),
+          height: Math.round((crop.bottom - crop.y) * scaleY),
         })
         .toPNG()
         .toString("base64");
+      return { png, requestedBounds: bounds, crop, display: display.bounds };
     });
     const file = path.join(this.artifactDir, `${name}.composed.png`);
-    await fs.writeFile(file, Buffer.from(data, "base64"));
+    await fs.writeFile(file, Buffer.from(data.png, "base64"));
+    const { png: _png, ...geometry } = data;
+    await this.writeJson(`${name}.composed.json`, geometry);
     return file;
   }
 
-  async capture(label: string): Promise<void> {
+  async capture(label: string) {
     const errors: string[] = [];
     const bestEffort = async (action: () => Promise<unknown>) => {
       try {
@@ -391,12 +431,17 @@ export class AppSession {
     await bestEffort(async () => {
       composed = await this.composedCapture(label);
     });
-    await this.writeJson(`${label}.evidence.json`, {
+    const summary = {
+      status: errors.length ? ("partial" as const) : ("complete" as const),
       errors,
+      composedCapture: composed ?? (this.headless ? "unsupported" : "unavailable"),
+    };
+    await this.writeJson(`${label}.evidence.json`, {
+      ...summary,
       journal: this.journal,
       rendererScreenshotsIncludeNativeLayers: false,
-      composedCapture: composed ?? (this.headless ? "unsupported" : "unavailable"),
     });
+    return summary;
   }
 
   async stop(): Promise<void> {

--- a/e2e/automation/session.ts
+++ b/e2e/automation/session.ts
@@ -214,8 +214,9 @@ export class AppSession {
           const cdp = await this.app.context().newCDPSession(page);
           try {
             const { targetInfo } = await cdp.send("Target.getTargetInfo");
+            if (!this.pages.has(targetInfo.targetId))
+              this.record("page-discovered", { id: targetInfo.targetId, url: page.url() });
             this.pages.set(targetInfo.targetId, page);
-            this.record("page-discovered", { id: targetInfo.targetId, url: page.url() });
             if (targetInfo.targetId === target.cdpTargetId) return page;
           } finally {
             await cdp.detach();
@@ -359,7 +360,21 @@ export class AppSession {
       const visibleWindows = BrowserWindow.getAllWindows().filter(
         (candidate) => candidate.isVisible() && !candidate.isMinimized(),
       );
-      const rectangles = visibleWindows.map((candidate) => candidate.getBounds());
+      const rectangles = visibleWindows.map((candidate) => {
+        const bounds = candidate.getBounds();
+        // Only maximized Windows windows have invisible borders to remove. Clip each
+        // such window before the union; normal windows and separate popups may truly span displays.
+        if (process.platform !== "win32" || !candidate.isMaximized()) return bounds;
+        const display = screen.getDisplayMatching(bounds).bounds;
+        const x = Math.max(bounds.x, display.x);
+        const y = Math.max(bounds.y, display.y);
+        return {
+          x,
+          y,
+          width: Math.min(bounds.x + bounds.width, display.x + display.width) - x,
+          height: Math.min(bounds.y + bounds.height, display.y + display.height) - y,
+        };
+      });
       if (!rectangles.length) throw new Error("No visible application windows");
       const left = Math.min(...rectangles.map((rect) => rect.x));
       const top = Math.min(...rectangles.map((rect) => rect.y));

--- a/e2e/automation/session.ts
+++ b/e2e/automation/session.ts
@@ -297,6 +297,10 @@ export class AppSession {
         frames.push({ data: frame.data, timestamp: frame.metadata.timestamp });
       cdp.send("Page.screencastFrameAck", { sessionId: frame.sessionId }).catch(() => {});
     });
+    let actionFailed = false;
+    let actionError: unknown;
+    let writeFailed = false;
+    let writeError: unknown;
     try {
       await cdp.send("Page.startScreencast", {
         format: "png",
@@ -305,17 +309,38 @@ export class AppSession {
         maxHeight: 800,
       });
       await action();
+    } catch (error) {
+      actionFailed = true;
+      actionError = error;
     } finally {
-      await cdp.send("Page.stopScreencast");
-      await cdp.detach();
-      const manifest = [];
-      for (const [index, frame] of frames.entries()) {
-        const file = `${label}.frame-${String(index).padStart(3, "0")}.png`;
-        await fs.writeFile(path.join(this.artifactDir, file), Buffer.from(frame.data, "base64"));
-        manifest.push({ file, timestamp: frame.timestamp });
+      const errors: string[] = [];
+      await cdp.send("Page.stopScreencast").catch((error) => {
+        errors.push(String(error));
+      });
+      await cdp.detach().catch((error) => {
+        errors.push(String(error));
+      });
+      try {
+        const manifest = [];
+        for (const [index, frame] of frames.entries()) {
+          const file = `${label}.frame-${String(index).padStart(3, "0")}.png`;
+          await fs.writeFile(path.join(this.artifactDir, file), Buffer.from(frame.data, "base64"));
+          manifest.push({ file, timestamp: frame.timestamp });
+        }
+        await this.writeJson(`${label}.frames.json`, {
+          target,
+          composed: false,
+          frames: manifest,
+          errors,
+        });
+      } catch (error) {
+        this.record("filmstrip-write-error", String(error));
+        writeFailed = true;
+        writeError = error;
       }
-      await this.writeJson(`${label}.frames.json`, { target, composed: false, frames: manifest });
     }
+    if (actionFailed) throw actionError;
+    if (writeFailed) throw writeError;
   }
 
   /** OS-composed display crop. Headless has no desktop compositor and must not claim this evidence. */

--- a/e2e/automation/session.ts
+++ b/e2e/automation/session.ts
@@ -1,0 +1,447 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { type ElectronApplication, _electron as electron, type Page } from "playwright";
+import type { RecordedEntry } from "../../src/features/debug-server/recorder";
+import type { DebugTarget } from "../../src/features/debug-server/targets.shared";
+import { waitUntil } from "./wait";
+
+interface Hooks {
+  ready: boolean;
+  getDebugPort(): number | null;
+}
+
+export class AppSession {
+  app!: ElectronApplication;
+  shell!: Page;
+  profile = "";
+  debugUrl = "";
+  generation = 0;
+  readonly token = randomUUID();
+  readonly journal: unknown[] = [];
+  readonly headless = process.platform === "linux" && process.env.CHIAROSCURO_HEADED !== "1";
+  private pages = new Map<string, Page>();
+  private running = false;
+  private lastTargets: DebugTarget[] = [];
+
+  constructor(readonly artifactDir: string) {}
+
+  record(kind: string, data: unknown): void {
+    this.journal.push({ time: new Date().toISOString(), generation: this.generation, kind, data });
+    if (this.journal.length > 2_000) this.journal.shift();
+  }
+
+  async launch(): Promise<void> {
+    await fs.mkdir(this.artifactDir, { recursive: true });
+    this.profile ||= await fs.mkdtemp(path.join(os.tmpdir(), "chiaroscuro-verify-"));
+    this.generation++;
+    this.pages.clear();
+    const args = [
+      ...(this.headless
+        ? [
+            "--ozone-platform=headless",
+            "--ozone-override-screen-size=1920,1080",
+            "--disable-gpu",
+            "--no-sandbox",
+          ]
+        : []),
+      path.resolve("out/main/index.js"),
+    ];
+    this.record("launch", { args, profile: this.profile });
+    try {
+      await fs.access("out/main/index.js").catch(() => {
+        throw new Error("Missing build. Run bun run build and bun run setup:electron first.");
+      });
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        NODE_ENV: "test",
+        DATA_DIR: this.profile,
+        CHIAROSCURO_AUTOMATION: "1",
+        CHIAROSCURO_DEBUG_TOKEN: this.token,
+      };
+      // A verification run must use the build under test, even from a dev terminal.
+      delete env.ELECTRON_RENDERER_URL;
+      delete env.ELECTRON_RUN_AS_NODE;
+      this.app = await electron.launch({
+        args,
+        env: Object.fromEntries(
+          Object.entries(env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+        ),
+        timeout: 20_000,
+      });
+      this.running = true;
+      this.app.process().stdout?.on("data", (chunk) => this.record("stdout", String(chunk)));
+      this.app.process().stderr?.on("data", (chunk) => this.record("stderr", String(chunk)));
+      this.app
+        .process()
+        .on("exit", (code, signal) => this.record("process-exit", { code, signal }));
+      this.app.on("console", (message) => this.record(`main:${message.type()}`, message.text()));
+      this.app.context().setDefaultTimeout(5_000);
+      const observePage = (page: Page) => {
+        page.on("console", (message) =>
+          this.record(`console:${message.type()}`, { url: page.url(), text: message.text() }),
+        );
+        page.on("pageerror", (error) =>
+          this.record("pageerror", { url: page.url(), error: String(error) }),
+        );
+        page.on("requestfailed", (request) =>
+          this.record("requestfailed", { url: request.url(), failure: request.failure() }),
+        );
+        page.on("response", (response) => {
+          if (response.status() >= 400)
+            this.record("http-error", { url: response.url(), status: response.status() });
+        });
+        page.on("crash", () => this.record("crash", page.url()));
+      };
+      this.app.context().pages().forEach(observePage);
+      this.app.context().on("page", observePage);
+      await this.app.context().tracing.start({ screenshots: true, snapshots: true, sources: true });
+      const port = await waitUntil(
+        "feature startup and debug listener",
+        () =>
+          this.app.evaluate(() => {
+            const hooks = (globalThis as unknown as { __testHooks?: Hooks }).__testHooks;
+            return hooks?.ready ? hooks.getDebugPort() : null;
+          }),
+        (port) => !!port,
+        15_000,
+      );
+      this.debugUrl = `http://127.0.0.1:${port}`;
+      this.shell = await this.page(await this.target((target) => target.kind === "shell"));
+      await this.shell
+        .locator("[data-testid='shell-ready']")
+        .waitFor({ state: "attached", timeout: 15_000 });
+      this.record("ready", await this.environment());
+    } catch (error) {
+      await this.writeJson("launch-failure.json", {
+        error: error instanceof Error ? error.stack : String(error),
+        rerun: "DEBUG=pw:browser bun run verify:app (on Windows, use $env:DEBUG='pw:browser')",
+        journal: this.journal,
+        runtime: process.versions,
+      });
+      await this.close().catch(() => {});
+      throw error;
+    }
+  }
+
+  async environment() {
+    return this.app.evaluate(({ app }) => ({
+      versions: process.versions,
+      platform: process.platform,
+      pid: process.pid,
+      userData: app.getPath("userData"),
+      argv: process.argv,
+    }));
+  }
+
+  async connection() {
+    const [port] = (
+      await fs.readFile(path.join(this.profile, "chromium", "DevToolsActivePort"), "utf8")
+    )
+      .trim()
+      .split("\n");
+    return { cdpUrl: `http://127.0.0.1:${port}`, debugUrl: this.debugUrl };
+  }
+
+  async debug<T = unknown>(endpoint: string, body?: unknown): Promise<T> {
+    const response = await fetch(`${this.debugUrl}${endpoint}`, {
+      headers: { Authorization: `Bearer ${this.token}`, "Content-Type": "application/json" },
+      ...(body === undefined ? {} : { method: "POST", body: JSON.stringify(body) }),
+      signal: AbortSignal.timeout(5_000),
+    });
+    const result = await response.json();
+    if (!response.ok) throw new Error(`${endpoint}: ${response.status} ${JSON.stringify(result)}`);
+    return result as T;
+  }
+
+  /** Scenario setup/diagnosis only; verify the changed behavior with real page input. */
+  async command<T = unknown>(name: string, payload?: unknown): Promise<T> {
+    this.record("setup-command", { name, payload });
+    const result = await this.debug<{ response: T }>("/commands/send", { name, payload });
+    this.record("command-result", { name, result });
+    return result.response;
+  }
+
+  async targets(): Promise<DebugTarget[]> {
+    this.lastTargets = await this.debug("/state/targets");
+    return this.lastTargets;
+  }
+
+  async target(predicate: (target: DebugTarget) => boolean): Promise<DebugTarget> {
+    const targets = await waitUntil(
+      "matching target",
+      () => this.targets(),
+      (targets) => targets.some(predicate),
+    );
+    const target = targets.find(predicate);
+    if (!target) throw new Error("Target disappeared");
+    return target;
+  }
+
+  async page(target: DebugTarget): Promise<Page> {
+    const cached = this.pages.get(target.cdpTargetId);
+    if (cached && !cached.isClosed()) return cached;
+    const page = await waitUntil(
+      `CDP page for ${target.id}`,
+      async () => {
+        for (const page of this.app.context().pages()) {
+          if (page.isClosed()) continue;
+          const cdp = await this.app.context().newCDPSession(page);
+          try {
+            const { targetInfo } = await cdp.send("Target.getTargetInfo");
+            this.pages.set(targetInfo.targetId, page);
+          } finally {
+            await cdp.detach();
+          }
+        }
+        return this.pages.get(target.cdpTargetId);
+      },
+      (page) => !!page,
+    );
+    if (!page) throw new Error(`No page for ${target.id}`);
+    return page;
+  }
+
+  async eventCursor(): Promise<number> {
+    const history = await this.debug<{ entries: RecordedEntry[] }>("/history?limit=1000");
+    return Math.max(0, ...history.entries.map((entry) => entry.id));
+  }
+
+  async waitForEvent(name: string, after: number): Promise<RecordedEntry> {
+    const result = await waitUntil(
+      `event ${name} after ${after}`,
+      () =>
+        this.debug<{ entries: RecordedEntry[] }>(
+          `/history?type=event&payload=true&limit=1000&name=${encodeURIComponent(name)}`,
+        ),
+      (history) => history.entries.some((entry) => entry.id > after),
+    );
+    const entry = result.entries.find((entry) => entry.id > after);
+    if (!entry) throw new Error("Event no longer retained");
+    return entry;
+  }
+
+  async inspect(target: DebugTarget) {
+    const page = await this.page(target);
+    return {
+      target,
+      accessibility: await page.locator("body").ariaSnapshot(),
+      dom: await page.evaluate(
+        (parentId) => ({
+          focus: document.activeElement?.outerHTML.slice(0, 1_000),
+          surfaces: [
+            ...document.querySelectorAll(
+              '[role="dialog"], [role="menu"], [role="listbox"], [aria-modal="true"]',
+            ),
+          ].map((element) => {
+            // Inspection IDs last as long as the DOM node; they never rename application IDs.
+            const id = element.getAttribute("data-verification-surface") ?? crypto.randomUUID();
+            element.setAttribute("data-verification-surface", id);
+            return {
+              role: element.getAttribute("role"),
+              label: element.getAttribute("aria-label"),
+              id: `surface:${id}`,
+              parentId,
+              selector: `[data-verification-surface="${id}"]`,
+              bounds: element.getBoundingClientRect().toJSON(),
+            };
+          }),
+          animations: document.getAnimations().map((animation) => ({
+            playState: animation.playState,
+            currentTime: animation.currentTime,
+          })),
+        }),
+        target.id,
+      ),
+    };
+  }
+
+  async writeJson(name: string, data: unknown): Promise<void> {
+    await fs.writeFile(path.join(this.artifactDir, name), JSON.stringify(data, null, 2));
+  }
+
+  /** Renderer filmstrip with compositor timestamps; not a whole-desktop video. */
+  async recordFrames(
+    target: DebugTarget,
+    label: string,
+    action: () => Promise<void>,
+  ): Promise<void> {
+    const cdp = await this.app.context().newCDPSession(await this.page(target));
+    const frames: { data: string; timestamp?: number }[] = [];
+    cdp.on("Page.screencastFrame", (frame) => {
+      if (frames.length < 90)
+        frames.push({ data: frame.data, timestamp: frame.metadata.timestamp });
+      cdp.send("Page.screencastFrameAck", { sessionId: frame.sessionId }).catch(() => {});
+    });
+    try {
+      await cdp.send("Page.startScreencast", {
+        format: "png",
+        everyNthFrame: 1,
+        maxWidth: 1200,
+        maxHeight: 800,
+      });
+      await action();
+    } finally {
+      await cdp.send("Page.stopScreencast");
+      await cdp.detach();
+      const manifest = [];
+      for (const [index, frame] of frames.entries()) {
+        const file = `${label}.frame-${String(index).padStart(3, "0")}.png`;
+        await fs.writeFile(path.join(this.artifactDir, file), Buffer.from(frame.data, "base64"));
+        manifest.push({ file, timestamp: frame.timestamp });
+      }
+      await this.writeJson(`${label}.frames.json`, { target, composed: false, frames: manifest });
+    }
+  }
+
+  /** OS-composed display crop. Headless has no desktop compositor and must not claim this evidence. */
+  async composedCapture(name: string): Promise<string> {
+    if (this.headless)
+      throw new Error(
+        "UNSUPPORTED: composed desktop capture on Ozone headless; use native Windows or CHIAROSCURO_HEADED=1 with X11.",
+      );
+    const data = await this.app.evaluate(async ({ BrowserWindow, desktopCapturer, screen }) => {
+      const win = BrowserWindow.getAllWindows().find((win) => !win.getParentWindow());
+      if (!win) throw new Error("No application window");
+      const visibleWindows = BrowserWindow.getAllWindows().filter(
+        (candidate) => candidate.isVisible() && !candidate.isMinimized(),
+      );
+      const rectangles = visibleWindows.map((candidate) => candidate.getBounds());
+      const left = Math.min(...rectangles.map((rect) => rect.x));
+      const top = Math.min(...rectangles.map((rect) => rect.y));
+      const bounds = {
+        x: left,
+        y: top,
+        width: Math.max(...rectangles.map((rect) => rect.x + rect.width)) - left,
+        height: Math.max(...rectangles.map((rect) => rect.y + rect.height)) - top,
+      };
+      const display = screen.getDisplayMatching(bounds);
+      if (
+        bounds.x < display.bounds.x ||
+        bounds.y < display.bounds.y ||
+        bounds.x + bounds.width > display.bounds.x + display.bounds.width ||
+        bounds.y + bounds.height > display.bounds.y + display.bounds.height
+      )
+        throw new Error("Window spans displays; move it onto one display before capture");
+      const sources = await desktopCapturer.getSources({
+        types: ["screen"],
+        thumbnailSize: {
+          width: Math.round(display.size.width * display.scaleFactor),
+          height: Math.round(display.size.height * display.scaleFactor),
+        },
+      });
+      const source = sources.find((source) => source.display_id === String(display.id));
+      if (!source || source.thumbnail.isEmpty())
+        throw new Error("Desktop capture unavailable on this runtime");
+      const size = source.thumbnail.getSize();
+      const scaleX = size.width / display.size.width;
+      const scaleY = size.height / display.size.height;
+      return source.thumbnail
+        .crop({
+          x: Math.round((bounds.x - display.bounds.x) * scaleX),
+          y: Math.round((bounds.y - display.bounds.y) * scaleY),
+          width: Math.round(bounds.width * scaleX),
+          height: Math.round(bounds.height * scaleY),
+        })
+        .toPNG()
+        .toString("base64");
+    });
+    const file = path.join(this.artifactDir, `${name}.composed.png`);
+    await fs.writeFile(file, Buffer.from(data, "base64"));
+    return file;
+  }
+
+  async capture(label: string): Promise<void> {
+    const errors: string[] = [];
+    const bestEffort = async (action: () => Promise<unknown>) => {
+      try {
+        await action();
+      } catch (error) {
+        errors.push(String(error));
+      }
+    };
+    await this.writeJson(`${label}.last-targets.json`, this.lastTargets);
+    await bestEffort(async () =>
+      this.writeJson(`${label}.state.json`, {
+        state: await this.debug("/state"),
+        history: await this.debug("/history?limit=1000&payload=true"),
+        log: await this.debug("/log?limit=1000&data=true"),
+        environment: await this.environment(),
+      }),
+    );
+    await bestEffort(async () => {
+      const targets = await this.targets();
+      await this.writeJson(`${label}.targets.json`, targets);
+      const seen = new Set<string>();
+      for (const target of targets) {
+        if (!target.visible || seen.has(target.cdpTargetId)) continue;
+        seen.add(target.cdpTargetId);
+        await bestEffort(async () => {
+          const stem = `${label}.${target.id.replaceAll(":", "-")}`;
+          await this.writeJson(`${stem}.inspection.json`, await this.inspect(target));
+          await (await this.page(target)).screenshot({
+            path: path.join(this.artifactDir, `${stem}.renderer.png`),
+            timeout: 3_000,
+          });
+        });
+      }
+    });
+    let composed: string | null = null;
+    await bestEffort(async () => {
+      composed = await this.composedCapture(label);
+    });
+    await this.writeJson(`${label}.evidence.json`, {
+      errors,
+      journal: this.journal,
+      rendererScreenshotsIncludeNativeLayers: false,
+      composedCapture: composed ?? (this.headless ? "unsupported" : "unavailable"),
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.running) return;
+    this.record("stop", { pid: this.app.process().pid });
+    try {
+      await this.app
+        .context()
+        .tracing.stop({ path: path.join(this.artifactDir, `trace-${this.generation}.zip`) });
+    } catch (error) {
+      this.record("trace-error", String(error));
+    } finally {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await Promise.race([
+          this.app.close(),
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(() => {
+              this.app.process().kill("SIGKILL");
+              reject(
+                new Error("Graceful shutdown timed out; terminated this verification process"),
+              );
+            }, 5_000);
+          }),
+        ]);
+      } finally {
+        clearTimeout(timer);
+        this.running = false;
+      }
+    }
+  }
+
+  async restart(): Promise<void> {
+    await this.capture(`before-restart-${this.generation}`);
+    await this.stop();
+    await this.launch();
+  }
+
+  async close(): Promise<void> {
+    try {
+      await this.stop();
+    } finally {
+      await this.writeJson("journal.json", this.journal);
+      if (this.profile)
+        await fs.rm(this.profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    }
+  }
+}

--- a/e2e/automation/site.ts
+++ b/e2e/automation/site.ts
@@ -1,0 +1,75 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+/** A small, valid PDF generated without an external service or binary tooling. */
+export function samplePdf(): Buffer {
+  const content = "BT /F1 24 Tf 40 740 Td (Chiaroscuro verification PDF) Tj ET";
+  const objects = [
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    `<< /Length ${content.length} >>\nstream\n${content}\nendstream`,
+  ];
+  let pdf = "%PDF-1.4\n";
+  const offsets = [0];
+  objects.forEach((object, i) => {
+    offsets.push(Buffer.byteLength(pdf));
+    pdf += `${i + 1} 0 obj\n${object}\nendobj\n`;
+  });
+  const xref = Buffer.byteLength(pdf);
+  pdf += `xref\n0 ${offsets.length}\n0000000000 65535 f \n`;
+  for (const offset of offsets.slice(1)) pdf += `${String(offset).padStart(10, "0")} 00000 n \n`;
+  pdf += `trailer\n<< /Size ${offsets.length} /Root 1 0 R >>\nstartxref\n${xref}\n%%EOF\n`;
+  return Buffer.from(pdf);
+}
+
+export async function startSite() {
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://localhost");
+    if (url.pathname === "/sample.pdf") {
+      response.writeHead(200, { "Content-Type": "application/pdf" });
+      response.end(samplePdf());
+      return;
+    }
+    if (url.pathname === "/download") {
+      response.writeHead(200, {
+        "Content-Type": "application/octet-stream",
+        "Content-Disposition": 'attachment; filename="verification.txt"',
+      });
+      response.end("deterministic download\n");
+      return;
+    }
+    if (url.pathname === "/failure") {
+      response.writeHead(503);
+      response.end("Intentional fixture failure");
+      return;
+    }
+    response.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    response.end(`<!doctype html><html lang="en"><meta charset="utf-8"><title>Verification ${url.pathname.replace(/[^a-z/-]/gi, "")}</title>
+      <style>body{font:20px system-ui;background:#e7edf5;color:#172a42;padding:32px}button,input,a{font:inherit;margin:12px;padding:8px}#scroll{height:180px;overflow:auto;border:2px solid}#spacer{height:600px}</style>
+      <h1>Local verification page</h1><label>Message <input aria-label="Message"></label><button id="apply">Apply</button><output id="result"></output>
+      <p><a href="/child" target="_blank">Open sub-tab</a><button id="popup">Open popup</button><a href="/sample.pdf">Read PDF</a><a href="/download">Download fixture</a></p>
+      <label>Upload fixture <input type="file" aria-label="Upload fixture"></label><output id="file"></output>
+      <button id="permission">Request notification permission</button><output id="permission-result"></output>
+      <div id="scroll" aria-label="Scrollable fixture"><div id="spacer">Scroll down</div><button>Bottom button</button></div>
+      <script>
+      document.querySelector('#apply').onclick=()=>document.querySelector('#result').textContent=document.querySelector('input').value;
+      document.querySelector('#popup').onclick=()=>window.open('/popup','verification-popup','width=500,height=400');
+      document.querySelector('[type=file]').onchange=e=>document.querySelector('#file').textContent=e.target.files[0]?.name;
+      document.querySelector('#permission').onclick=async()=>document.querySelector('#permission-result').textContent=await Notification.requestPermission();
+      </script></html>`);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  return {
+    url: `http://127.0.0.1:${(server.address() as AddressInfo).port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.closeAllConnections();
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}

--- a/e2e/automation/wait.ts
+++ b/e2e/automation/wait.ts
@@ -1,0 +1,36 @@
+/** Poll observations only. Never retry a click/command that may already have taken effect. */
+export async function waitUntil<T>(
+  description: string,
+  observe: () => Promise<T>,
+  accept: (value: T) => boolean,
+  timeoutMs = 5_000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let last: unknown;
+  let lastError: string | undefined;
+  while (Date.now() < deadline) {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const value = await Promise.race([
+        observe(),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error("Observation timed out")),
+            deadline - Date.now(),
+          );
+        }),
+      ]);
+      last = value;
+      if (accept(value)) return value;
+    } catch (error) {
+      lastError = String(error);
+    } finally {
+      clearTimeout(timer);
+    }
+    const remaining = deadline - Date.now();
+    if (remaining > 0) await new Promise((resolve) => setTimeout(resolve, Math.min(50, remaining)));
+  }
+  throw new Error(
+    `Timed out waiting for ${description}. Last observation: ${JSON.stringify(last)}. Last error: ${lastError ?? "none"}`,
+  );
+}

--- a/e2e/automation/windows-pointer.ps1
+++ b/e2e/automation/windows-pointer.ps1
@@ -1,0 +1,44 @@
+# Desktop input for an owned verification window; never click through an overlapping window.
+param(
+  [Parameter(Mandatory=$true)][int]$X,
+  [Parameter(Mandatory=$true)][int]$Y,
+  [Parameter(Mandatory=$true)][long]$ExpectedWindow,
+  [switch]$Click
+)
+$ErrorActionPreference = 'Stop'
+Add-Type @'
+using System;
+using System.Runtime.InteropServices;
+public class VerificationPointer {
+  [StructLayout(LayoutKind.Sequential)] public struct POINT { public int X, Y; }
+  [DllImport("user32.dll")] public static extern IntPtr SetThreadDpiAwarenessContext(IntPtr context);
+  [DllImport("user32.dll")] public static extern bool SetCursorPos(int x, int y);
+  [DllImport("user32.dll")] public static extern bool GetCursorPos(out POINT point);
+  [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")] public static extern IntPtr WindowFromPoint(POINT point);
+  [DllImport("user32.dll")] public static extern IntPtr GetAncestor(IntPtr window, uint flags);
+  [DllImport("user32.dll")] public static extern IntPtr SendMessageTimeout(IntPtr window, uint message, UIntPtr wParam, IntPtr lParam, uint flags, uint timeout, out UIntPtr result);
+  [DllImport("user32.dll")] public static extern void mouse_event(uint flags, uint dx, uint dy, uint data, UIntPtr extra);
+}
+'@
+# Electron supplies physical screen coordinates. Avoid PowerShell DPI virtualization.
+[VerificationPointer]::SetThreadDpiAwarenessContext([IntPtr]::new(-4)) | Out-Null
+if (-not [VerificationPointer]::SetCursorPos($X, $Y)) { throw 'Cannot move desktop pointer' }
+$point = New-Object VerificationPointer+POINT
+if (-not [VerificationPointer]::GetCursorPos([ref]$point)) { throw 'Cannot observe desktop pointer' }
+$root = [VerificationPointer]::GetAncestor([VerificationPointer]::WindowFromPoint($point), 2).ToInt64()
+$foreground = [VerificationPointer]::GetForegroundWindow().ToInt64()
+if ($root -ne $ExpectedWindow -or $foreground -ne $ExpectedWindow) {
+  throw "Owned window $ExpectedWindow is obscured or unfocused (pointer window $root, foreground $foreground)"
+}
+if ($point.X -ne $X -or $point.Y -ne $Y) { throw 'Pointer did not reach the requested position' }
+$hit = [UIntPtr]::Zero
+$packed = [IntPtr]::new((($Y -band 65535) -shl 16) -bor ($X -band 65535))
+# WM_NCHITTEST: 1 = HTCLIENT, 2 = HTCAPTION. Abort if the target is unresponsive.
+$sent = [VerificationPointer]::SendMessageTimeout([IntPtr]::new($root), 132, [UIntPtr]::Zero, $packed, 2, 1000, [ref]$hit)
+if ($sent -eq [IntPtr]::Zero) { throw 'Native hit-test timed out or failed' }
+if ($Click) {
+  [VerificationPointer]::mouse_event(2, 0, 0, 0, [UIntPtr]::Zero)
+  [VerificationPointer]::mouse_event(4, 0, 0, 0, [UIntPtr]::Zero)
+}
+@{ x=$point.X; y=$point.Y; window=$root; foreground=$foreground; hitTest=$hit.ToUInt64() } | ConvertTo-Json -Compress

--- a/e2e/automation/windows-pointer.ts
+++ b/e2e/automation/windows-pointer.ts
@@ -1,0 +1,61 @@
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { AppSession } from "./session";
+
+const run = promisify(execFile);
+
+/** Drive the OS pointer over the owned shell, including native title-bar hit testing. */
+export async function windowsPointer(
+  session: AppSession,
+  point: { x: number; y: number },
+  click = false,
+): Promise<{ x: number; y: number; window: number; foreground: number; hitTest: number }> {
+  if (process.platform !== "win32") throw new Error("UNSUPPORTED: Windows desktop input required");
+  const native = await session.app.evaluate(({ BrowserWindow, screen }, point) => {
+    const win = BrowserWindow.getAllWindows().find((candidate) => !candidate.getParentWindow());
+    if (!win) throw new Error("No owned shell window");
+    win.show();
+    win.focus();
+    const bounds = win.getContentBounds();
+    const zoom = win.webContents.getZoomFactor();
+    const x = point.x * zoom;
+    const y = point.y * zoom;
+    if (
+      !Number.isFinite(x) ||
+      !Number.isFinite(y) ||
+      x < 0 ||
+      y < 0 ||
+      x >= bounds.width ||
+      y >= bounds.height
+    )
+      throw new Error("Pointer position is outside the owned shell");
+    const handle = win.getNativeWindowHandle();
+    return {
+      ...screen.dipToScreenPoint({ x: Math.round(bounds.x + x), y: Math.round(bounds.y + y) }),
+      handle: (handle.length === 8
+        ? handle.readBigUInt64LE()
+        : BigInt(handle.readUInt32LE())
+      ).toString(),
+    };
+  }, point);
+  const result = await run(
+    "powershell.exe",
+    [
+      "-NoProfile",
+      "-File",
+      path.resolve("e2e/automation/windows-pointer.ps1"),
+      "-X",
+      String(native.x),
+      "-Y",
+      String(native.y),
+      "-ExpectedWindow",
+      native.handle,
+      ...(click ? ["-Click"] : []),
+    ],
+    { timeout: 5_000, windowsHide: true },
+  );
+  const observation = JSON.parse(result.stdout);
+  session.record("windows-pointer", { point, click, ...observation });
+  return observation;
+}

--- a/e2e/diagnostics/address-bar.ts
+++ b/e2e/diagnostics/address-bar.ts
@@ -1,0 +1,175 @@
+import path from "node:path";
+import type { RecordedEntry } from "../../src/features/debug-server/recorder";
+import { AppSession } from "../automation/session";
+import { startSite } from "../automation/site";
+import { waitUntil } from "../automation/wait";
+import { windowsPointer } from "../automation/windows-pointer";
+import { VerificationPage } from "../pages/verification.page";
+
+if (process.platform !== "win32") {
+  throw new Error("Run natively on Windows, or use bun run verify:app:win --address-bar from WSL.");
+}
+const artifactDir = path.resolve(
+  "test-results",
+  "address-bar",
+  new Date().toISOString().replaceAll(":", "-"),
+);
+const session = new AppSession(artifactDir);
+const site = await startSite();
+const observations: {
+  input: string;
+  name: string;
+  part: string;
+  activated: boolean;
+  hovered: boolean;
+  hitTest?: number;
+  color: string;
+  command: string;
+  copyMatches?: boolean;
+}[] = [];
+let previousClipboard: string | undefined;
+try {
+  await session.launch();
+  previousClipboard = await session.app.evaluate(({ clipboard }) => clipboard.readText());
+  if (process.argv.includes("--maximized")) {
+    await session.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows()
+        .find((win) => !win.getParentWindow())
+        ?.maximize(),
+    );
+  }
+  const cases = [
+    { name: "Reload", command: "window:reload" },
+    { name: "Copy URL", command: "window:copy-address" },
+    { name: "Domain customization", command: "domain-settings:open" },
+  ];
+  for (const input of ["cdp", "windows"] as const) {
+    for (const { name, command } of cases) {
+      for (const part of ["icon", "padding"] as const) {
+        const url = `${site.url}/address-bar-hit-test`;
+        const fixture = await VerificationPage.navigate(session, url);
+        await fixture.message.waitFor({ state: "visible" });
+        const button = session.shell.getByRole("button", { name, exact: true });
+        await button.waitFor({ state: "visible" });
+        const geometry = await button.evaluate((button) => {
+          const rect = (element: Element) => {
+            const r = element.getBoundingClientRect();
+            return { x: r.x, y: r.y, width: r.width, height: r.height };
+          };
+          const icon = button.querySelector("i");
+          if (!icon) throw new Error("Button icon missing");
+          const parent = button.parentElement;
+          if (!parent) throw new Error("Button container missing");
+          return {
+            button: rect(button),
+            icon: rect(icon),
+            regions: [icon, button, parent].map((element) => ({
+              tag: element.tagName,
+              appRegion: getComputedStyle(element).getPropertyValue("app-region"),
+              pointerEvents: getComputedStyle(element).pointerEvents,
+            })),
+          };
+        });
+        const box = part === "icon" ? geometry.icon : geometry.button;
+        const point = {
+          x: box.x + (part === "icon" ? box.width / 2 : 2),
+          y: box.y + box.height / 2,
+        };
+        const label = `${input}-${name.replaceAll(" ", "-")}-${part}`;
+        await session.writeJson(`${label}.geometry.json`, { geometry, point });
+        const native = input === "windows" ? await windowsPointer(session, point) : undefined;
+        if (input === "cdp") await session.shell.mouse.move(point.x, point.y);
+        const hover = await button.evaluate(async (element) => {
+          await new Promise<void>((resolve) =>
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+          );
+          return { hovered: element.matches(":hover"), color: getComputedStyle(element).color };
+        });
+        await session.shell.screenshot({
+          path: path.join(artifactDir, `${label}.hover.renderer.png`),
+        });
+        await session.app.evaluate(({ clipboard }) =>
+          clipboard.writeText("address-bar-diagnostic-sentinel"),
+        );
+        const cursor = await session.eventCursor();
+        if (input === "windows") await windowsPointer(session, point, true);
+        else await session.shell.mouse.click(point.x, point.y);
+        let activated = false;
+        try {
+          await waitUntil(
+            command,
+            () =>
+              session.debug<{ entries: RecordedEntry[] }>(
+                `/history?type=command&name=${encodeURIComponent(command)}&limit=100`,
+              ),
+            (history) => history.entries.some((entry) => entry.id > cursor),
+            750,
+          );
+          activated = true;
+        } catch (error) {
+          session.record("diagnostic-missing-command", String(error));
+        }
+        const copyMatches =
+          name === "Copy URL"
+            ? (await session.app.evaluate(({ clipboard }) => clipboard.readText())) === url
+            : undefined;
+        const observation = {
+          input,
+          name,
+          part,
+          ...hover,
+          hitTest: native?.hitTest,
+          command,
+          activated,
+          copyMatches,
+        };
+        observations.push(observation);
+        session.record("address-bar-observation", observation);
+        console.log(JSON.stringify(observation));
+      }
+    }
+  }
+  const controlWorks = observations.some(
+    (o) => o.input === "windows" && o.name === "Reload" && o.activated,
+  );
+  const affected = observations.filter((o) => o.input === "windows" && o.name !== "Reload");
+  const blockedIcons = affected
+    .filter((o) => o.part === "icon")
+    .every((o) => !o.activated && o.hitTest === 2);
+  const workingPadding = affected.filter((o) => o.part === "padding").every((o) => o.activated);
+  const outcome = !controlWorks
+    ? "inconclusive-control-failed"
+    : blockedIcons
+      ? workingPadding
+        ? "reported-behavior-reproduced"
+        : "icons-blocked-padding-also-blocked"
+      : "reported-behavior-not-reproduced";
+  const evidence = await session.capture("diagnostic");
+  const result = {
+    outcome,
+    controlWorks,
+    observations,
+    evidenceStatus: evidence.status,
+    artifactDir,
+  };
+  await session.writeJson("result.json", result);
+  console.log(JSON.stringify(result));
+  if (!controlWorks || evidence.status !== "complete") process.exitCode = 1;
+} catch (error) {
+  process.exitCode = 1;
+  await session.writeJson("result.json", {
+    outcome: "diagnostic-failed",
+    error: String(error),
+    observations,
+  });
+  await session.capture("failure").catch(() => {});
+  throw error;
+} finally {
+  if (previousClipboard !== undefined) {
+    await session.app
+      .evaluate(({ clipboard }, text) => clipboard.writeText(text), previousClipboard)
+      .catch(() => {});
+  }
+  await session.close();
+  await site.close();
+}

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -1,51 +1,41 @@
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { test as base } from "@playwright/test";
-import { type ElectronApplication, _electron as electron, type Page } from "playwright";
+import type { ElectronApplication, Page } from "playwright";
+import { AppSession } from "../automation/session";
 
 type ElectronFixtures = {
+  appSession: AppSession;
   electronApp: ElectronApplication;
   shellPage: Page;
 };
 
 export const test = base.extend<ElectronFixtures>({
-  // biome-ignore lint/correctness/noEmptyPattern: Playwright fixture signature requires destructured first arg
-  electronApp: async ({}, use) => {
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "chiaroscuro-test-"));
-    const args = [
-      ...(process.platform === "linux"
-        ? [
-            "--ozone-platform=headless",
-            // Electron 44's headless display otherwise constrains windows to 1x1.
-            "--ozone-override-screen-size=1920,1080",
-            "--disable-gpu",
-            "--no-sandbox",
-          ]
-        : []),
-      "./out/main/index.js",
-    ];
-    const app = await electron.launch({
-      args,
-      env: {
-        ...process.env,
-        NODE_ENV: "test",
-        DATA_DIR: tmpDir,
-      },
-    });
-    await use(app);
-    await app.close();
-    await fs.rm(tmpDir, { recursive: true, force: true });
+  appSession: [
+    // biome-ignore lint/correctness/noEmptyPattern: Playwright requires destructured fixtures
+    async ({}, use, testInfo) => {
+      const session = new AppSession(testInfo.outputPath("evidence"));
+      try {
+        await session.launch();
+        await use(session);
+      } finally {
+        await session.writeJson("result.json", {
+          status: testInfo.status,
+          expectedStatus: testInfo.expectedStatus,
+          errors: testInfo.errors,
+          title: testInfo.title,
+          rerun: `bun run ${testInfo.project.testDir.endsWith("scenarios") ? "verify:app" : "e2e"} --grep ${JSON.stringify(testInfo.title)}`,
+        });
+        if (testInfo.status !== testInfo.expectedStatus) await session.capture("failure");
+        await session.close();
+      }
+    },
+    { timeout: 30_000 },
+  ],
+  electronApp: async ({ appSession }, use) => {
+    await use(appSession.app);
   },
-
-  shellPage: async ({ electronApp }, use) => {
-    const page = await electronApp.firstWindow();
-    await page.waitForSelector("[data-testid='shell-ready']", {
-      state: "attached",
-      timeout: 15_000,
-    });
-    await page.emulateMedia({ reducedMotion: "reduce" });
-    await use(page);
+  shellPage: async ({ appSession }, use) => {
+    await appSession.shell.emulateMedia({ reducedMotion: "reduce" });
+    await use(appSession.shell);
   },
 });
 

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -17,18 +17,22 @@ export const test = base.extend<ElectronFixtures>({
         await session.launch();
         await use(session);
       } finally {
-        await session.writeJson("result.json", {
-          status: testInfo.status,
-          expectedStatus: testInfo.expectedStatus,
-          errors: testInfo.errors,
-          title: testInfo.title,
-          rerun: `bun run ${testInfo.project.testDir.endsWith("scenarios") ? "verify:app" : "e2e"} --grep ${JSON.stringify(testInfo.title)}`,
-        });
-        if (testInfo.status !== testInfo.expectedStatus) await session.capture("failure");
-        await session.close();
+        try {
+          await session.writeJson("result.json", {
+            status: testInfo.status,
+            expectedStatus: testInfo.expectedStatus,
+            errors: testInfo.errors,
+            title: testInfo.title,
+            rerun: `bun run ${testInfo.project.testDir.endsWith("scenarios") ? "verify:app" : "e2e"} --grep ${JSON.stringify(testInfo.title)}`,
+          });
+          if (testInfo.status !== testInfo.expectedStatus) await session.capture("failure");
+        } finally {
+          await session.close();
+        }
       }
     },
-    { timeout: 30_000 },
+    // Covers bounded launch steps plus failure evidence/cleanup without raising test deadlines.
+    { timeout: 90_000 },
   ],
   electronApp: async ({ appSession }, use) => {
     await use(appSession.app);

--- a/e2e/pages/verification.page.ts
+++ b/e2e/pages/verification.page.ts
@@ -1,0 +1,58 @@
+import type { Page } from "playwright";
+import type { AppSession } from "../automation/session";
+
+export class VerificationPage {
+  constructor(readonly page: Page) {}
+  get message() {
+    return this.page.getByRole("textbox", { name: "Message", exact: true });
+  }
+  get result() {
+    return this.page.locator("#result");
+  }
+  get subTab() {
+    return this.page.getByRole("link", { name: "Open sub-tab" });
+  }
+  get popup() {
+    return this.page.getByRole("button", { name: "Open popup" });
+  }
+  get upload() {
+    return this.page.getByLabel("Upload fixture");
+  }
+  get uploadedFile() {
+    return this.page.locator("#file");
+  }
+  get scrollArea() {
+    return this.page.getByLabel("Scrollable fixture");
+  }
+  get download() {
+    return this.page.getByRole("link", { name: "Download fixture" });
+  }
+  get pdf() {
+    return this.page.getByRole("link", { name: "Read PDF" });
+  }
+
+  async submit(message: string) {
+    await this.message.click();
+    await this.message.pressSequentially(message);
+    await this.page.getByRole("button", { name: "Apply", exact: true }).click();
+  }
+
+  static async navigate(session: AppSession, url: string) {
+    // Exercise the actual shortcut, palette window and navigation entry point.
+    // Electron's before-input-event shortcuts require native input, not CDP keyboard dispatch.
+    await session.app.evaluate(({ BrowserWindow }) => {
+      const win = BrowserWindow.getAllWindows().find((win) => !win.getParentWindow());
+      if (!win) throw new Error("No shell window");
+      win.webContents.sendInputEvent({ type: "keyDown", keyCode: "T", modifiers: ["control"] });
+      win.webContents.sendInputEvent({ type: "keyUp", keyCode: "T", modifiers: ["control"] });
+    });
+    const palette = await session.page(await session.target((target) => target.kind === "palette"));
+    const input = palette.getByRole("textbox", { name: "Search or enter URL" });
+    await input.fill(url);
+    await input.press("Enter");
+    const target = await session.target(
+      (target) => target.kind === "tab" && target.url === url && target.visible,
+    );
+    return new VerificationPage(await session.page(target));
+  }
+}

--- a/e2e/scenarios/verification.spec.ts
+++ b/e2e/scenarios/verification.spec.ts
@@ -176,7 +176,23 @@ test("sidebar drag reorders real tabs and records animation frames", async ({
 });
 
 test("intentional failure produces reproducible evidence", async ({ appSession: session }) => {
-  await VerificationPage.navigate(session, `${site.url}/evidence`);
+  const parent = await VerificationPage.navigate(session, `${site.url}/evidence`);
+  await parent.popup.click();
+  const popupTarget = await session.target(
+    (target) => target.kind === "window" && target.url === `${site.url}/popup`,
+  );
+  const popup = new VerificationPage(await session.page(popupTarget));
+  await expect(
+    session.recordFrames(popupTarget, "closed-target", async () => {
+      await popup.submit("before target closes");
+      await popup.page.close();
+      throw new Error("Intentional action failure after closing target");
+    }),
+  ).rejects.toThrow("Intentional action failure after closing target");
+  const closedTargetFrames = JSON.parse(
+    await fs.readFile(path.join(session.artifactDir, "closed-target.frames.json"), "utf8"),
+  );
+  expect(closedTargetFrames.errors.length).toBeGreaterThan(0);
   let failure = "";
   try {
     await waitUntil(

--- a/e2e/scenarios/verification.spec.ts
+++ b/e2e/scenarios/verification.spec.ts
@@ -1,0 +1,209 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { startSite } from "../automation/site";
+import { waitUntil } from "../automation/wait";
+import { expect, test } from "../fixtures/electron-app";
+import { VerificationPage } from "../pages/verification.page";
+import { WindowChromePage } from "../pages/window-chrome.page";
+
+let site: Awaited<ReturnType<typeof startSite>>;
+test.beforeAll(async () => {
+  site = await startSite();
+});
+test.afterAll(async () => {
+  await site.close();
+});
+
+test("cross-window and sub-tab focus through visible UI", async ({ appSession: session }) => {
+  const parent = await VerificationPage.navigate(session, `${site.url}/parent`);
+  await parent.submit("parent input");
+  await expect(parent.result).toHaveText("parent input");
+  const cursor = await session.eventCursor();
+  await parent.subTab.click();
+  await session.waitForEvent("sub-tabs:opened", cursor);
+  const childTarget = await session.target(
+    (target) => target.kind === "sub-tab" && target.url === `${site.url}/child` && target.visible,
+  );
+  expect(childTarget.parentId).toMatch(/^tab:/);
+  const child = new VerificationPage(await session.page(childTarget));
+  await child.submit("child input");
+  await expect(child.result).toHaveText("child input");
+  await child.message.click();
+  await expect(child.message).toBeFocused();
+  await session.capture("sub-tab");
+  const frame = await session.page(
+    await session.target((target) => target.kind === "sub-tab-frame"),
+  );
+  await frame.getByRole("button", { name: "Close sub-tab", exact: true }).click();
+  await waitUntil(
+    "sub-tab removal",
+    () => session.targets(),
+    (targets) => !targets.some((target) => target.id === childTarget.id),
+  );
+
+  await parent.popup.click();
+  const popupTarget = await session.target(
+    (target) => target.kind === "window" && target.url === `${site.url}/popup`,
+  );
+  expect(popupTarget.parentId).toMatch(/^window:/);
+  const popup = new VerificationPage(await session.page(popupTarget));
+  await popup.submit("popup input");
+  await expect(popup.result).toHaveText("popup input");
+  await session.capture("popup");
+  await popup.page.close();
+  await parent.message.click();
+  await expect(parent.message).toBeFocused();
+  await expect(parent.result).toHaveText("parent input");
+});
+
+test("PDF toolbar zoom survives a full process restart", async ({ appSession: session }) => {
+  const parent = await VerificationPage.navigate(session, `${site.url}/pdf-source`);
+  await parent.pdf.click();
+  const zoomIn = session.shell.getByRole("button", { name: "Zoom in", exact: true });
+  const zoomReset = session.shell.getByRole("button", { name: "Reset zoom", exact: true });
+  await expect(zoomReset).toHaveText("100%");
+  await zoomIn.click();
+  await expect(zoomReset).toHaveText("125%");
+  await waitUntil(
+    "PDF zoom command completion",
+    () =>
+      session.debug<{ entries: { name: string; error?: string }[] }>(
+        "/history?name=pdf-reader:set-zoom",
+      ),
+    (history) => history.entries.some((entry) => !entry.error),
+  );
+  const oldPid = session.app.process().pid;
+  const oldProfile = session.profile;
+  await session.restart();
+  expect(session.app.process().pid).not.toBe(oldPid);
+  expect(session.profile).toBe(oldProfile);
+  // Select the restored PDF in the sidebar, rather than reopening it through an internal command.
+  const pdfTarget = await session.target(
+    (target) => target.kind === "built-in" && target.url.startsWith("app:pdf-reader"),
+  );
+  await session.shell.locator(`[data-tab-id="${pdfTarget.tabId}"]`).click();
+  await expect(session.shell.getByRole("button", { name: "Reset zoom", exact: true })).toHaveText(
+    "125%",
+  );
+  await expect(session.shell.locator("canvas").first()).toBeVisible();
+  await session.capture("pdf-restored");
+});
+
+test("pointer resize, clipboard, file selection and deterministic download", async ({
+  appSession: session,
+}) => {
+  const page = await VerificationPage.navigate(session, `${site.url}/interactions`);
+  await session.command("permissions:set", {
+    domain: "127.0.0.1",
+    permission: "notifications",
+    decision: "deny",
+  });
+  await page.page.getByRole("button", { name: "Request notification permission" }).click();
+  await expect(page.page.locator("#permission-result")).toHaveText("denied");
+  await page.upload.setInputFiles({
+    name: "fixture.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("local fixture"),
+  });
+  await expect(page.uploadedFile).toHaveText("fixture.txt");
+  await page.scrollArea.hover();
+  await page.page.mouse.wheel(0, 500);
+  await expect
+    .poll(() => page.scrollArea.evaluate((element) => element.scrollTop))
+    .toBeGreaterThan(100);
+  const chrome = new WindowChromePage(session.shell);
+  const clipboardBefore = await session.app.evaluate(({ clipboard }) => clipboard.readText());
+  try {
+    await chrome.copyUrlButton.click();
+    await expect
+      .poll(() => session.app.evaluate(({ clipboard }) => clipboard.readText()))
+      .toBe(`${site.url}/interactions`);
+  } finally {
+    await session.app.evaluate(async ({ clipboard }, text) => {
+      await clipboard.writeText(text);
+    }, clipboardBefore);
+  }
+
+  const cursor = await session.eventCursor();
+  await page.download.click();
+  await session.waitForEvent("downloads:completed", cursor);
+  expect(
+    await fs.readFile(path.join(session.profile, "downloads", "verification.txt"), "utf8"),
+  ).toBe("deterministic download\n");
+  const separator = session.shell.getByRole("separator");
+  const before = Number(await separator.getAttribute("aria-valuenow"));
+  const bounds = await separator.boundingBox();
+  if (!bounds) throw new Error("Sidebar resize handle has no bounds");
+  await session.shell.mouse.move(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2);
+  await session.shell.mouse.down();
+  await session.shell.mouse.move(bounds.x + 60, bounds.y + bounds.height / 2, { steps: 12 });
+  await session.shell.mouse.up();
+  await expect
+    .poll(async () => Number(await separator.getAttribute("aria-valuenow")))
+    .toBeGreaterThan(before + 40);
+  await chrome.maximizeButton.click();
+  await expect
+    .poll(() =>
+      session.debug<{ maximized: boolean }>("/state/window").then((state) => state.maximized),
+    )
+    .toBe(true);
+  await session.capture("interactions");
+});
+
+test("sidebar drag reorders real tabs and records animation frames", async ({
+  appSession: session,
+}) => {
+  await VerificationPage.navigate(session, `${site.url}/drag-first`);
+  await VerificationPage.navigate(session, `${site.url}/drag-second`);
+  const tabs = session.shell.locator("nav[aria-label='Sidebar'] [data-tab-id]");
+  await expect(tabs).toHaveCount(2);
+  const firstId = await tabs.first().getAttribute("data-tab-id");
+  const lastId = await tabs.last().getAttribute("data-tab-id");
+  await session.recordFrames(
+    await session.target((target) => target.kind === "shell"),
+    "sidebar-drag",
+    async () => {
+      await tabs.last().dragTo(tabs.first(), { targetPosition: { x: 30, y: 2 } });
+      await expect(tabs.first()).toHaveAttribute("data-tab-id", lastId ?? "missing");
+      await expect(tabs.last()).toHaveAttribute("data-tab-id", firstId ?? "missing");
+    },
+  );
+  await session.capture("sidebar-reordered");
+  const filmstrip = JSON.parse(
+    await fs.readFile(path.join(session.artifactDir, "sidebar-drag.frames.json"), "utf8"),
+  );
+  expect(filmstrip.frames.length).toBeGreaterThan(0);
+});
+
+test("intentional failure produces reproducible evidence", async ({ appSession: session }) => {
+  await VerificationPage.navigate(session, `${site.url}/evidence`);
+  let failure = "";
+  try {
+    await waitUntil(
+      "intentional missing tab",
+      () => session.targets(),
+      (targets) => targets.some((target) => target.id === "tab:intentionally-missing"),
+      200,
+    );
+  } catch (error) {
+    failure = String(error);
+    await session.capture("intentional-failure");
+  }
+  expect(failure).toContain("intentional missing tab");
+  await session.writeJson("intentional-failure.result.json", {
+    status: "failed",
+    expected: true,
+    error: failure,
+    rerun: "bun run verify:app --grep 'intentional failure'",
+  });
+  const files = await fs.readdir(session.artifactDir);
+  expect(files).toContain("intentional-failure.targets.json");
+  expect(files).toContain("intentional-failure.state.json");
+  expect(files.some((file) => file.endsWith("renderer.png"))).toBe(true);
+  const unauthenticated = await fetch(`${session.debugUrl}/state`);
+  expect(unauthenticated.status).toBe(401);
+  const browserOrigin = await fetch(`${session.debugUrl}/state`, {
+    headers: { Origin: site.url, Authorization: `Bearer ${session.token}` },
+  });
+  expect(browserOrigin.status).toBe(403);
+});

--- a/e2e/scenarios/verification.spec.ts
+++ b/e2e/scenarios/verification.spec.ts
@@ -30,7 +30,7 @@ test("cross-window and sub-tab focus through visible UI", async ({ appSession: s
   await expect(child.result).toHaveText("child input");
   await child.message.click();
   await expect(child.message).toBeFocused();
-  await session.capture("sub-tab");
+  expect((await session.capture("sub-tab")).status).toBe("complete");
   const frame = await session.page(
     await session.target((target) => target.kind === "sub-tab-frame"),
   );
@@ -49,7 +49,7 @@ test("cross-window and sub-tab focus through visible UI", async ({ appSession: s
   const popup = new VerificationPage(await session.page(popupTarget));
   await popup.submit("popup input");
   await expect(popup.result).toHaveText("popup input");
-  await session.capture("popup");
+  expect((await session.capture("popup")).status).toBe("complete");
   await popup.page.close();
   await parent.message.click();
   await expect(parent.message).toBeFocused();
@@ -86,7 +86,7 @@ test("PDF toolbar zoom survives a full process restart", async ({ appSession: se
     "125%",
   );
   await expect(session.shell.locator("canvas").first()).toBeVisible();
-  await session.capture("pdf-restored");
+  expect((await session.capture("pdf-restored")).status).toBe("complete");
 });
 
 test("pointer resize, clipboard, file selection and deterministic download", async ({
@@ -147,7 +147,7 @@ test("pointer resize, clipboard, file selection and deterministic download", asy
       session.debug<{ maximized: boolean }>("/state/window").then((state) => state.maximized),
     )
     .toBe(true);
-  await session.capture("interactions");
+  expect((await session.capture("interactions")).status).toBe("complete");
 });
 
 test("sidebar drag reorders real tabs and records animation frames", async ({
@@ -168,7 +168,7 @@ test("sidebar drag reorders real tabs and records animation frames", async ({
       await expect(tabs.last()).toHaveAttribute("data-tab-id", firstId ?? "missing");
     },
   );
-  await session.capture("sidebar-reordered");
+  expect((await session.capture("sidebar-reordered")).status).toBe("complete");
   const filmstrip = JSON.parse(
     await fs.readFile(path.join(session.artifactDir, "sidebar-drag.frames.json"), "utf8"),
   );
@@ -187,7 +187,7 @@ test("intentional failure produces reproducible evidence", async ({ appSession: 
     );
   } catch (error) {
     failure = String(error);
-    await session.capture("intentional-failure");
+    expect((await session.capture("intentional-failure")).status).toBe("complete");
   }
   expect(failure).toContain("intentional missing tab");
   await session.writeJson("intentional-failure.result.json", {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "setup:electron": "install-electron",
     "verify:app": "bun run setup:electron && bun e2e/automation/run.ts",
     "verify:app:win": "bash scripts/verify-app-win.sh",
-    "agent:app": "bun build e2e/automation/cli.ts --target=node --packages=external --outfile=out/verification/cli.mjs && node out/verification/cli.mjs",
+    "agent:app": "bun run setup:electron && bun build e2e/automation/cli.ts --target=node --packages=external --outfile=out/verification/cli.mjs && node out/verification/cli.mjs",
     "diagnose:address-bar": "bun run setup:electron && bun build e2e/diagnostics/address-bar.ts --target=node --packages=external --outfile=out/verification/address-bar.mjs && node out/verification/address-bar.mjs"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,13 +20,16 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
-    "typecheck": "tsc --build",
+    "typecheck": "tsc --build && tsc --project tsconfig.e2e.json",
     "dev:win": "./scripts/dev-win.sh",
     "verify": "./scripts/verify-all.sh",
     "docs:dev": "bun run generate:icons && vite --config design-system/vite.config.ts",
     "docs:build": "bun run generate:icons && vite build --config design-system/vite.config.ts",
     "docs:preview": "vite preview --config design-system/vite.config.ts",
-    "setup:electron": "install-electron"
+    "setup:electron": "install-electron",
+    "verify:app": "bun run setup:electron && bun e2e/automation/run.ts",
+    "verify:app:win": "bash scripts/verify-app-win.sh",
+    "agent:app": "bun build e2e/automation/cli.ts --target=node --packages=external --outfile=out/verification/cli.mjs && node out/verification/cli.mjs"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.3.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "setup:electron": "install-electron",
     "verify:app": "bun run setup:electron && bun e2e/automation/run.ts",
     "verify:app:win": "bash scripts/verify-app-win.sh",
-    "agent:app": "bun build e2e/automation/cli.ts --target=node --packages=external --outfile=out/verification/cli.mjs && node out/verification/cli.mjs"
+    "agent:app": "bun build e2e/automation/cli.ts --target=node --packages=external --outfile=out/verification/cli.mjs && node out/verification/cli.mjs",
+    "diagnose:address-bar": "bun run setup:electron && bun build e2e/diagnostics/address-bar.ts --target=node --packages=external --outfile=out/verification/address-bar.mjs && node out/verification/address-bar.mjs"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.3.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./e2e",
+  testIgnore: "**/scenarios/**",
+  outputDir: "test-results/e2e",
   timeout: 5_000, // DO NOT increase — tests must be fast; fix the test instead
   globalTimeout: 300_000,
   retries: 0,

--- a/playwright.verification.config.ts
+++ b/playwright.verification.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e/scenarios",
+  // Each scenario includes evidence collection and may include a complete process restart.
+  timeout: 30_000,
+  globalTimeout: 180_000,
+  retries: 0,
+  workers: 1,
+  outputDir: "test-results/verification",
+  reporter: [["list"], ["json", { outputFile: "test-results/verification/results.json" }]],
+});

--- a/playwright.verification.config.ts
+++ b/playwright.verification.config.ts
@@ -4,7 +4,8 @@ export default defineConfig({
   testDir: "./e2e/scenarios",
   // Each scenario includes evidence collection and may include a complete process restart.
   timeout: 30_000,
-  globalTimeout: 180_000,
+  // Five serial scenarios: 90s setup + 30s body + 90s teardown each, plus suite hooks.
+  globalTimeout: 1_200_000,
   retries: 0,
   workers: 1,
   outputDir: "test-results/verification",

--- a/scripts/verification-desktop.sh
+++ b/scripts/verification-desktop.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+for prerequisite in openbox obxprop xcompmgr; do
+  command -v "$prerequisite" >/dev/null || { echo "Missing $prerequisite. Install xvfb, xauth, openbox and xcompmgr for Linux verification." >&2; exit 1; }
+done
+mkdir -p test-results
+openbox >test-results/desktop.log 2>&1 &
+manager=$!
+xcompmgr -c >test-results/compositor.log 2>&1 &
+compositor=$!
+trap 'kill "$manager" "$compositor" 2>/dev/null || true' EXIT
+# Wait on the EWMH readiness property instead of assuming the desktop has started.
+ready=false
+for _ in {1..100}; do
+  if ! kill -0 "$manager" 2>/dev/null; then cat test-results/desktop.log >&2; exit 1; fi
+  if ! kill -0 "$compositor" 2>/dev/null; then cat test-results/compositor.log >&2; exit 1; fi
+  if obxprop --root _NET_SUPPORTING_WM_CHECK 2>/dev/null | grep -q '(WINDOW) ='; then ready=true; break; fi
+  sleep 0.05
+done
+if [[ "$ready" != true ]]; then echo "Window manager readiness timed out; inspect test-results/desktop.log" >&2; exit 1; fi
+"$@"

--- a/scripts/verify-app-win.sh
+++ b/scripts/verify-app-win.sh
@@ -11,6 +11,7 @@ VERIFY_DIR="$(wslpath "$WIN_PROFILE")/.chiaroscuro-verification"
 mkdir -p "$VERIFY_DIR"
 MODE=verify:app
 if [[ "${1:-}" == "--interactive" ]]; then MODE=agent:app; shift; fi
+if [[ "${1:-}" == "--address-bar" ]]; then MODE=diagnose:address-bar; shift; fi
 bun run build
 rsync -a --delete out e2e src resources "$VERIFY_DIR/"
 cp package.json bun.lock bunfig.toml playwright.verification.config.ts "$VERIFY_DIR/"

--- a/scripts/verify-app-win.sh
+++ b/scripts/verify-app-win.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Run the same Playwright/Electron fixture natively on Windows from WSL.
+set -euo pipefail
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_DIR"
+for prerequisite in powershell.exe wslpath rsync; do
+  command -v "$prerequisite" >/dev/null || { echo "Missing $prerequisite. Run this launcher from WSL with Windows interop enabled." >&2; exit 1; }
+done
+WIN_PROFILE=$(powershell.exe -NoProfile -Command 'Write-Output $env:USERPROFILE' | tr -d '\r')
+VERIFY_DIR="$(wslpath "$WIN_PROFILE")/.chiaroscuro-verification"
+mkdir -p "$VERIFY_DIR"
+MODE=verify:app
+if [[ "${1:-}" == "--interactive" ]]; then MODE=agent:app; shift; fi
+bun run build
+rsync -a --delete out e2e src resources "$VERIFY_DIR/"
+cp package.json bun.lock bunfig.toml playwright.verification.config.ts "$VERIFY_DIR/"
+python3 - "$VERIFY_DIR/arguments.json" "$MODE" "$@" <<'PY'
+import json, sys
+with open(sys.argv[1], 'w') as f:
+    json.dump({'command': sys.argv[2], 'args': sys.argv[3:]}, f)
+PY
+cat > "$VERIFY_DIR/run.ps1" <<'PS'
+$ErrorActionPreference = 'Stop'
+Set-Location $PSScriptRoot
+New-Item -ItemType Directory -Force test-results | Out-Null
+Start-Transcript -Path test-results\launcher.log -Force | Out-Null
+$env:DEBUG = 'pw:browser'
+if (Test-Path "$PSScriptRoot\runtime") { $env:PATH = "$PSScriptRoot\runtime;" + $env:PATH }
+if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
+  $candidate = Join-Path $env:USERPROFILE '.bun\bin\bun.exe'
+  if (Test-Path $candidate) { $env:PATH = (Split-Path $candidate) + ';' + $env:PATH }
+}
+if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
+  throw 'Missing native Windows Bun. Install Bun 1.3.11+ on Windows and rerun bun run verify:app:win.'
+}
+$version = [version](bun --version)
+if ($version -lt [version]'1.3.11') { throw 'Windows Bun 1.3.11+ is required.' }
+if (-not (Get-Command node -ErrorAction SilentlyContinue)) { throw 'Install Node.js 24.20.0 LTS on Windows for Playwright.' }
+$nodeVersion = [version]((node --version).TrimStart('v'))
+if ($nodeVersion -lt [version]'24.15.0') { throw 'Node.js 24.15+ is required; the repository pins 24.20.0 LTS.' }
+bun install --frozen-lockfile
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+$request = Get-Content -Raw arguments.json | ConvertFrom-Json
+$scenarioArgs = @($request.args)
+bun run $request.command @scenarioArgs
+$result = $LASTEXITCODE
+Stop-Transcript | Out-Null
+exit $result
+PS
+set +e
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$(wslpath -w "$VERIFY_DIR/run.ps1")"
+result=$?
+set -e
+mkdir -p test-results/windows
+if [ -d "$VERIFY_DIR/test-results" ]; then
+  rsync -a "$VERIFY_DIR/test-results/" test-results/windows/
+fi
+exit "$result"

--- a/src/features/app-state/app-state.main.ts
+++ b/src/features/app-state/app-state.main.ts
@@ -52,7 +52,7 @@ export default defineFeature<Deps>({
     });
 
     commands.handle(APP_STATE_SAVE, async () => {
-      state.flush();
+      await state.flush();
     });
   },
 

--- a/src/features/debug-server/debug-server.main.ts
+++ b/src/features/debug-server/debug-server.main.ts
@@ -15,6 +15,8 @@ import { getDebugState, getDebugStateNames } from "./state-providers";
 const startTime = Date.now();
 let server: http.Server | null = null;
 let actualPort: number | null = null;
+const automation = process.env.NODE_ENV === "test" && process.env.CHIAROSCURO_AUTOMATION === "1";
+const automationToken = automation ? process.env.CHIAROSCURO_DEBUG_TOKEN : undefined;
 
 type AllCommands = DebugServerCommands;
 type AllEvents = Pick<SettingsEvents, typeof SETTINGS_CHANGED>;
@@ -72,7 +74,6 @@ function respond(res: http.ServerResponse, status: number, data: unknown, pretty
   const body = safeStringify(data, pretty);
   res.writeHead(status, {
     "Content-Type": "application/json",
-    "Access-Control-Allow-Origin": "*",
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type",
   });
@@ -85,7 +86,19 @@ function handleRequest(
   commandBus: CommandBus<CommandRegistry>,
   eventBus: EventBus<EventRegistry>,
 ): void {
-  const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  // Browser pages must not be able to drive a local debug server, including through DNS rebinding.
+  if (req.headers.origin || !/^(127\.0\.0\.1|localhost)(:\d+)?$/.test(req.headers.host ?? "")) {
+    respond(res, 403, { error: "Debug access requires a local non-browser client" }, false);
+    return;
+  }
+  if (
+    automation &&
+    (!automationToken || req.headers.authorization !== `Bearer ${automationToken}`)
+  ) {
+    respond(res, 401, { error: "This test instance requires its debug bearer token" }, false);
+    return;
+  }
+  const url = new URL(req.url ?? "/", "http://127.0.0.1");
   const pretty = url.searchParams.has("pretty");
 
   // CORS preflight
@@ -308,9 +321,9 @@ function startServer(
       });
       srv.listen(tryPort, "127.0.0.1", () => {
         server = srv;
-        actualPort = tryPort;
-        debugLog.info("debug-server", `Listening on 127.0.0.1:${tryPort}`);
-        resolve(tryPort);
+        actualPort = (srv.address() as import("node:net").AddressInfo).port;
+        debugLog.info("debug-server", `Listening on 127.0.0.1:${actualPort}`);
+        resolve(actualPort);
       });
     }
     tryListen(port);
@@ -336,7 +349,7 @@ export default defineFeature<Deps>({
     // Register recorder early to capture all subsequent registrations
     registerRecorder(commandBus, eventBus);
 
-    let configuredPort = 19400;
+    let configuredPort = automation ? 0 : 19400;
     let enabled = false;
 
     commands.handle(DEBUG_SERVER_START, async () => {
@@ -350,8 +363,8 @@ export default defineFeature<Deps>({
 
     events.on(SETTINGS_CHANGED, (payload) => {
       const { settings } = payload as SettingsChangedEvent;
-      const newEnabled = isDev || settings.debugServer.enabled;
-      const newPort = settings.debugServer.port;
+      const newEnabled = automation || isDev || settings.debugServer.enabled;
+      const newPort = automation ? 0 : settings.debugServer.port;
 
       const needsRestart = newEnabled !== enabled || (newEnabled && newPort !== configuredPort);
       enabled = newEnabled;

--- a/src/features/debug-server/targets.shared.ts
+++ b/src/features/debug-server/targets.shared.ts
@@ -1,0 +1,25 @@
+import type { Bounds } from "../../shared/types";
+
+/** IDs are stable for the lifetime of their native object; tab IDs survive restart. */
+export interface DebugTarget {
+  id: string;
+  kind:
+    | "shell"
+    | "window"
+    | "palette"
+    | "sub-tab-frame"
+    | "tooltip"
+    | "tab"
+    | "sub-tab"
+    | "built-in";
+  windowId: number | null;
+  parentId: string | null;
+  tabId?: string;
+  webContentsId: number;
+  cdpTargetId: string;
+  url: string;
+  title: string;
+  bounds: Bounds;
+  visible: boolean;
+  focused: boolean;
+}

--- a/src/features/pdf-reader/pdf-reader.main.ts
+++ b/src/features/pdf-reader/pdf-reader.main.ts
@@ -20,6 +20,7 @@ import {
   PDF_READER_INDEX_DELETE,
   PDF_READER_INDEX_REORDER,
   PDF_READER_INDEX_UPDATE,
+  PDF_READER_SET_ZOOM,
   type PdfReaderCommands,
   type PdfReaderEvents,
   type PersistedPdfIndex,
@@ -127,11 +128,32 @@ export default defineFeature<Deps>({
       const data = await fetchPdfData(url);
       const hash = computeHash(data);
       const filename = extractFilename(url);
+      const savedZoom = await dataStore.getSetting<number>(`pdf-zoom:${filename}:${hash}`);
       return {
         dataBase64: data.toString("base64"),
         hash,
         filename,
+        zoom:
+          typeof savedZoom === "number" &&
+          Number.isFinite(savedZoom) &&
+          savedZoom >= 0.25 &&
+          savedZoom <= 5
+            ? savedZoom
+            : 1,
       };
+    });
+
+    commands.handle(PDF_READER_SET_ZOOM, async ({ pdfKey, zoom }) => {
+      if (
+        typeof pdfKey !== "string" ||
+        !pdfKey ||
+        !Number.isFinite(zoom) ||
+        zoom < 0.25 ||
+        zoom > 5
+      ) {
+        throw new Error("PDF zoom requires a nonempty pdfKey and a finite zoom between 0.25 and 5");
+      }
+      await dataStore.setSetting(`pdf-zoom:${pdfKey}`, zoom);
     });
 
     // ── Index CRUD ────────────────────────────────────────────────

--- a/src/features/pdf-reader/pdf-reader.renderer.tsx
+++ b/src/features/pdf-reader/pdf-reader.renderer.tsx
@@ -4,7 +4,7 @@ import type { PdfBackend, PdfDocument, SearchMatch } from "./backends/types";
 import { IndexSidebar } from "./components/IndexSidebar";
 import { PdfToolbar } from "./components/PdfToolbar";
 import { PdfViewport } from "./components/PdfViewport";
-import type { IndexEntry, PdfBackendType } from "./pdf-reader.shared";
+import type { IndexEntry, PdfBackendType, PdfFetchResponse } from "./pdf-reader.shared";
 import { usePdfReaderStore } from "./pdf-reader.store";
 
 const ZOOM_STEP = 0.25;
@@ -162,11 +162,9 @@ export default function PdfReaderPage({ params }: BuiltInPageProps) {
         const response = await window.chiaroscuro.sendCommand("pdf-reader:fetch", { url });
         if (cancelled) return;
 
-        const { dataBase64, hash, filename } = response as {
-          dataBase64: string;
-          hash: string;
-          filename: string;
-        };
+        const { dataBase64, hash, filename, zoom: savedZoom } = response as PdfFetchResponse;
+        updateViewState(url, { zoom: savedZoom });
+        setZoom(savedZoom);
 
         const key = `${filename}:${hash}`;
         setPdfKey(key);
@@ -395,13 +393,15 @@ export default function PdfReaderPage({ params }: BuiltInPageProps) {
   const handleZoomChange = useCallback(
     (updater: (zoom: number) => number) => {
       beforeZoomChangeRef.current?.();
-      setZoom((z) => {
-        const nextZoom = updater(z);
-        updateViewState(pdfUrl, { zoom: nextZoom });
-        return nextZoom;
-      });
+      const nextZoom = updater(getViewState(pdfUrl).zoom);
+      updateViewState(pdfUrl, { zoom: nextZoom });
+      setZoom(nextZoom);
+      if (pdfKey)
+        window.chiaroscuro
+          .sendCommand("pdf-reader:set-zoom", { pdfKey, zoom: nextZoom })
+          .catch((error: unknown) => console.error("Failed to save PDF zoom", error));
     },
-    [pdfUrl],
+    [pdfUrl, pdfKey],
   );
   const handleToggleIndex = useCallback(() => {
     setIndexVisible((visible) => {

--- a/src/features/pdf-reader/pdf-reader.shared.ts
+++ b/src/features/pdf-reader/pdf-reader.shared.ts
@@ -1,5 +1,6 @@
 // ── Command names ────────────────────────────────────────────────
 export const PDF_READER_FETCH = "pdf-reader:fetch" as const;
+export const PDF_READER_SET_ZOOM = "pdf-reader:set-zoom" as const;
 export const PDF_READER_GET_INDEX = "pdf-reader:get-index" as const;
 export const PDF_READER_INDEX_ADD = "pdf-reader:index-add" as const;
 export const PDF_READER_INDEX_UPDATE = "pdf-reader:index-update" as const;
@@ -30,6 +31,7 @@ export interface PdfFetchResponse {
   dataBase64: string;
   hash: string;
   filename: string;
+  zoom: number;
 }
 
 // ── Payload types ────────────────────────────────────────────────
@@ -71,6 +73,7 @@ export interface PdfIndexChangedEvent {
 
 // ── Command registry ─────────────────────────────────────────────
 export type PdfReaderCommands = {
+  [PDF_READER_SET_ZOOM]: { payload: { pdfKey: string; zoom: number }; response: undefined };
   [PDF_READER_FETCH]: { payload: PdfFetchPayload; response: PdfFetchResponse };
   [PDF_READER_GET_INDEX]: { payload: PdfGetIndexPayload; response: IndexEntry[] };
   [PDF_READER_INDEX_ADD]: { payload: PdfIndexAddPayload; response: undefined };

--- a/src/features/pdf-reader/pdf-reader.test.ts
+++ b/src/features/pdf-reader/pdf-reader.test.ts
@@ -69,6 +69,9 @@ describe("pdf-reader commands", () => {
       expect(
         (await restored.send(PDF_READER_FETCH, { url: "https://fixture.test/sample.pdf" })).zoom,
       ).toBe(1.25);
+      expect(
+        (await restored.send(PDF_READER_FETCH, { url: "https://fixture.test/other.pdf" })).zoom,
+      ).toBe(1);
       for (const zoom of [Number.NaN, Infinity, 0, 5.25]) {
         await expect(restored.send(PDF_READER_SET_ZOOM, { pdfKey, zoom })).rejects.toThrow(
           "finite zoom",

--- a/src/features/pdf-reader/pdf-reader.test.ts
+++ b/src/features/pdf-reader/pdf-reader.test.ts
@@ -15,6 +15,7 @@ import {
   PDF_READER_INDEX_DELETE,
   PDF_READER_INDEX_REORDER,
   PDF_READER_INDEX_UPDATE,
+  PDF_READER_SET_ZOOM,
   type PdfIndexChangedEvent,
   type PdfReaderCommands,
   type PdfReaderEvents,
@@ -51,6 +52,36 @@ function setup() {
 }
 
 describe("pdf-reader commands", () => {
+  it("restores zoom by document identity after feature recreation", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("%PDF-1.4 test document")),
+    );
+    try {
+      const { commands, deps, dataStore } = setup();
+      const pdf = await commands.send(PDF_READER_FETCH, { url: "https://fixture.test/sample.pdf" });
+      expect(pdf.zoom).toBe(1);
+      const pdfKey = `${pdf.filename}:${pdf.hash}`;
+      await commands.send(PDF_READER_SET_ZOOM, { pdfKey, zoom: 1.25 });
+      feature.teardown?.();
+      const restored = new CommandBus<AllCommands>();
+      feature.register({ ...deps, dataStore, commands: restored });
+      expect(
+        (await restored.send(PDF_READER_FETCH, { url: "https://fixture.test/sample.pdf" })).zoom,
+      ).toBe(1.25);
+      for (const zoom of [Number.NaN, Infinity, 0, 5.25]) {
+        await expect(restored.send(PDF_READER_SET_ZOOM, { pdfKey, zoom })).rejects.toThrow(
+          "finite zoom",
+        );
+      }
+      expect(
+        (await restored.send(PDF_READER_FETCH, { url: "https://fixture.test/sample.pdf" })).zoom,
+      ).toBe(1.25);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   describe("PDF_READER_GET_INDEX", () => {
     it("returns empty array for unknown PDF", async () => {
       const { commands } = setup();

--- a/src/features/sub-tabs/sub-tabs.main.ts
+++ b/src/features/sub-tabs/sub-tabs.main.ts
@@ -552,3 +552,9 @@ export function hasSubTabs(tabId: TabId): boolean {
   const stack = stacks.get(tabId);
   return !!stack && stack.length > 0;
 }
+
+export function getSubTabSnapshot(): SubTab[] {
+  return _state.initialized
+    ? [..._state.get().stacks.values()].flat().map((tab) => ({ ...tab }))
+    : [];
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,3 +1,4 @@
+import { mkdirSync } from "node:fs";
 import path from "node:path";
 import { app, BrowserWindow, ipcMain, Menu, screen } from "electron";
 import { CommandBus } from "../bus/command-bus";
@@ -80,7 +81,7 @@ import {
 } from "../features/settings/settings.shared";
 import sidebar from "../features/sidebar/sidebar.main";
 import type { SidebarCommands, SidebarEvents } from "../features/sidebar/sidebar.shared";
-import subTabs from "../features/sub-tabs/sub-tabs.main";
+import subTabs, { getSubTabSnapshot } from "../features/sub-tabs/sub-tabs.main";
 import type { SubTabsCommands, SubTabsEvents } from "../features/sub-tabs/sub-tabs.shared";
 import tabContextMenu from "../features/tab-context-menu/tab-context-menu.main";
 import type {
@@ -139,6 +140,20 @@ const iconPath = path.join(__dirname, "../../resources", iconFile);
 // Use a separate app identity so dev instances don't conflict with
 // the production single-instance lock or userData.
 const isDev = !!process.env.ELECTRON_RENDERER_URL;
+const isAutomation = process.env.NODE_ENV === "test" && process.env.CHIAROSCURO_AUTOMATION === "1";
+// Isolate Chromium cookies, caches, sessions and the single-instance lock, not just our JSON data.
+if (process.env.NODE_ENV === "test") {
+  if (!process.env.DATA_DIR || !path.isAbsolute(process.env.DATA_DIR)) {
+    throw new Error("Tests require an absolute DATA_DIR; use the Electron verification fixture.");
+  }
+  const chromiumProfile = path.join(process.env.DATA_DIR, "chromium");
+  mkdirSync(chromiumProfile, { recursive: true });
+  app.setPath("userData", chromiumProfile);
+  const downloadsPath = path.join(process.env.DATA_DIR, "downloads");
+  mkdirSync(downloadsPath, { recursive: true });
+  app.setPath("desktop", downloadsPath);
+  app.setPath("downloads", downloadsPath);
+}
 if (isDev) {
   app.setName("Chiaroscuro Dev");
 }
@@ -225,14 +240,15 @@ let activeWindowId: WindowId | undefined;
 let activeTabId: TabId | undefined;
 let activeWorkspaceId: WorkspaceId | undefined;
 
-if (isDev) app.setPath("userData", path.join(app.getPath("userData"), "..", "chiaroscuro-dev"));
+if (isDev && process.env.NODE_ENV !== "test")
+  app.setPath("userData", path.join(app.getPath("userData"), "..", "chiaroscuro-dev"));
 const platform = new ElectronPlatform(() => activeWindowId);
 const dataDir = process.env.DATA_DIR ?? path.join(app.getPath("userData"), "data");
 const dataStore: DataStore = createDataStore(dataDir);
 
 function initOverlays(): void {
   if (!activeWindowId) return;
-  if (process.env.NODE_ENV !== "test") {
+  if (process.env.NODE_ENV !== "test" || isAutomation) {
     platform.initTooltipOverlay(activeWindowId);
   }
   platform.initCommandPaletteOverlay(activeWindowId);
@@ -308,6 +324,12 @@ const deps = {
 };
 
 if (gotLock) {
+  app.on("render-process-gone", (_event, contents, details) => {
+    logError("main", "renderer process exited")({ webContentsId: contents.id, ...details });
+  });
+  app.on("child-process-gone", (_event, details) => {
+    logError("main", "child process exited")(details);
+  });
   app.whenReady().then(async () => {
     await dataStore.initialize();
 
@@ -391,6 +413,38 @@ if (gotLock) {
       };
     });
     registerDebugState("debug-server", () => ({ actualPort: getActualPort() }));
+    registerDebugState("sub-tabs", getSubTabSnapshot);
+    registerDebugState("targets", () => {
+      const targets = platform.getDebugTargets();
+      const shell = targets.find((target) => target.windowId === Number(activeWindowId));
+      if (shell) shell.kind = "shell";
+      for (const target of targets) {
+        const subTab = getSubTabSnapshot().find((tab) => tab.id === target.tabId);
+        if (subTab) {
+          target.kind = "sub-tab";
+          target.parentId = `tab:${subTab.parentTabId}`;
+        }
+      }
+      for (const [id, tab] of getAllTabs()) {
+        if (tab.builtIn && shell)
+          targets.push({
+            ...shell,
+            id: `tab:${id}`,
+            kind: "built-in",
+            tabId: id,
+            parentId: shell.id,
+            url: tab.url,
+            title: tab.title,
+            visible: activeTabId === id && shell.visible,
+          });
+      }
+      return targets;
+    });
+    if (isAutomation) {
+      Object.assign(globalThis, {
+        __testHooks: { commandBus: commands, getDebugPort: getActualPort, ready: false },
+      });
+    }
 
     // Load persisted layout state before creating the window
     const getDisplayBounds = () => screen.getAllDisplays().map((d) => d.workArea);
@@ -426,6 +480,10 @@ if (gotLock) {
       await startLocalWebApp(deps);
       await externalLink.start?.(deps);
       await permissions.start?.(deps);
+      if (isAutomation)
+        Object.assign((globalThis as unknown as { __testHooks: object }).__testHooks, {
+          ready: true,
+        });
     });
 
     const win = createWindow(appStateData.windowBounds);
@@ -451,19 +509,25 @@ if (gotLock) {
     });
   });
 
-  app.on("before-quit", () => {
+  let quitting = false;
+  app.on("before-quit", (event) => {
+    if (quitting) return;
     platform.deactivateShortcuts();
     debugServer.teardown?.();
     localWebApp.teardown?.();
     installer.teardown?.();
     externalLink.teardown?.();
     // Skip expensive persistence in test mode — speeds up Playwright teardown
-    if (process.env.NODE_ENV === "test") return;
+    if (process.env.NODE_ENV === "test" && !isAutomation) return;
+    event.preventDefault();
+    quitting = true;
     // Flush app-state immediately before data store teardown
     commands
       .send("app-state:save", undefined)
       .catch(logError("main", "flush app-state"))
-      .finally(() => dataStore.destroy().catch(logError("main", "destroy datastore")));
+      .then(() => dataStore.destroy())
+      .catch(logError("main", "destroy datastore"))
+      .finally(() => app.quit());
   });
 
   app.on("window-all-closed", () => {

--- a/src/platform/electron.ts
+++ b/src/platform/electron.ts
@@ -273,6 +273,56 @@ document.addEventListener('keydown',function(e){if(e.key==='Escape')closePalette
 </script></body></html>`;
 
 export class ElectronPlatform implements Platform {
+  /** Read-only native inventory shared by HTTP discovery and Electron verification. */
+  getDebugTargets(): import("../features/debug-server/targets.shared").DebugTarget[] {
+    const windows = BrowserWindow.getAllWindows().filter((win) => !win.isDestroyed());
+    const targets: import("../features/debug-server/targets.shared").DebugTarget[] = windows.map(
+      (win) => ({
+        id: `window:${win.id}`,
+        kind:
+          win === this.paletteWin
+            ? "palette"
+            : win === this.subTabWin
+              ? "sub-tab-frame"
+              : win === this.tooltipWin
+                ? "tooltip"
+                : win.webContents.getURL().includes("/out/renderer/")
+                  ? "shell"
+                  : "window",
+        windowId: win.id,
+        parentId: win.getParentWindow() ? `window:${win.getParentWindow()?.id}` : null,
+        webContentsId: win.webContents.id,
+        cdpTargetId: win.webContents.getOrCreateDevToolsTargetId(),
+        url: win.webContents.getURL(),
+        title: win.getTitle(),
+        bounds: win.getBounds(),
+        visible: win.isVisible() && !win.isMinimized(),
+        focused: win.webContents.isFocused(),
+      }),
+    );
+    for (const [tabId, view] of this.views) {
+      if (view.webContents.isDestroyed()) continue;
+      const owner = windows.find((win) => win.contentView.children.includes(view));
+      const bounds = view.getBounds();
+      targets.push({
+        id: `tab:${tabId}`,
+        kind: "tab",
+        tabId,
+        windowId: owner?.id ?? null,
+        parentId: owner ? `window:${owner.id}` : null,
+        webContentsId: view.webContents.id,
+        cdpTargetId: view.webContents.getOrCreateDevToolsTargetId(),
+        url: view.webContents.getURL(),
+        title: view.webContents.getTitle(),
+        bounds,
+        visible:
+          !!owner?.isVisible() && !owner.isMinimized() && bounds.width > 0 && bounds.height > 0,
+        focused: view.webContents.isFocused(),
+      });
+    }
+    return targets;
+  }
+
   private shortcuts = new Map<string, () => void>();
   private localShortcuts = new Map<string, () => void>();
   private views = new Map<TabId, WebContentsView>();
@@ -925,7 +975,7 @@ export class ElectronPlatform implements Platform {
 
   private ensureSubTabWindow(): void {
     if (this.subTabWin && !this.subTabWin.isDestroyed()) return;
-    if (process.env.NODE_ENV === "test") return;
+    if (process.env.NODE_ENV === "test" && process.env.CHIAROSCURO_AUTOMATION !== "1") return;
 
     const parent = this.getWin();
     if (!parent) return;

--- a/src/shared/debounced-save.ts
+++ b/src/shared/debounced-save.ts
@@ -36,11 +36,11 @@ export class DebouncedSave<T> {
     }, this.debounceMs);
   }
 
-  flush(): void {
+  async flush(): Promise<void> {
     if (this.timer !== undefined) {
       clearTimeout(this.timer);
       this.timer = undefined;
-      this.save(this.value).catch(logError("debounced-save", "persist"));
+      await this.save(this.value);
     }
   }
 }

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "target": "ES2024",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": [
+    "e2e/**/*",
+    "playwright*.config.ts",
+    "src/features/debug-server/targets.shared.ts",
+    "src/features/debug-server/recorder.ts",
+    "src/bus/command-bus.ts",
+    "src/bus/event-bus.ts",
+    "src/bus/types.ts",
+    "src/shared/types.ts",
+    "src/renderer/src/env.d.ts"
+  ]
+}


### PR DESCRIPTION
Agents can now launch an isolated copy of the actual Electron browser, select native tab/overlay targets, drive visible UI, restart with the same profile, and collect diagnostic and visual evidence without manual setup. The interactive controller and repeatable scenarios share the existing Playwright fixture and HTTP debug server.

The workflow isolates Chromium cookies/cache and downloads as well as application data, uses random ports and a test debug token, waits on readiness/conditions/events, and records target relationships, accessibility/focus, command results, console/network errors, traces, composed screenshots and renderer filmstrips. The controller buffers startup input and reports partial captures explicitly; scenarios require complete evidence bundles. Linux desktop scenarios use Xvfb, Openbox and xcompmgr; a WSL launcher runs the same fixture natively on Windows. CI runs both platforms and uploads evidence.

Five local scenarios cover palette → tab → sub-tab/popup focus, PDF zoom across a complete process restart, pointer resizing/clipboard/file input/permissions/downloads/native maximize, sidebar drag with animation frames, and an intentional assertion failure with reproducible evidence. The restart scenario exposed renderer-only PDF zoom: zoom now persists by document identity, and shutdown waits for final saves. Browse/debug skills and testing/design-system documentation describe the workflow and remaining gaps.

Windows manual-testing instructions now require deploying the complete build and launching its local renderer, so the browser remains usable without WSL or an agent session. An optional address-bar diagnostic compares CDP with native Windows pointer input, records native hit-test results, and uses Reload as a positive control. It reproduced blocked icons in #51; that product bug remains open and is not fixed here.

Validation:
- `bun run verify`: typecheck (including E2E/controller code), lint, repository checks and 601 tests pass.
- `bun run build` and `bun run docs:build` pass.
- `bun run e2e`: 56 tests pass.
- `bun run verify:app`: five scenarios pass under Linux Xvfb/Openbox; inspected PDF and native sub-tab composed screenshots.
- Exercised the interactive controller through inspection, keyboard navigation, capture, restart and cleanup; both updated skills validate.
- Native Windows CI passes all five scenarios with complete capture bundles; inspected its composed sub-tab and restored PDF screenshots.
- Ran the optional native Windows address-bar diagnostic through the WSL launcher: all 12 comparisons completed, Reload worked, and affected controls returned HTCAPTION while CDP clicks passed. Padding also failed, so the narrower edge-working detail was not confirmed. This local diagnostic reported partial evidence and exited nonzero because desktop capture was unavailable; renderer images and native input records were retained.
- Built and deployed the complete app to Windows and verified its local-file renderer for independent manual testing.

Gaps are explicit in `docs/testing/agent-verification.md`: OS pickers/permission menus, external-app drag/drop, global hotkey conflicts, multi-display capture, and independent main browser windows. Ozone headless cannot prove desktop composition and its native popup path can crash, so those scenarios use a desktop runtime. Feature command schemas remain the separate scope of #44; controller schema discovery does not claim to validate feature payloads.

Closes #47.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - PDF Viewer zoom levels now persist for each document across application restarts.
  - Added application verification workflows for Linux and native Windows environments, including visual evidence and failure diagnostics.
  - Added interactive automation and inspection support for application verification.

- **Bug Fixes**
  - Application state saves now complete reliably before shutdown or command completion.
  - PDF zoom values are validated to prevent invalid settings from being stored.

- **Documentation**
  - Updated testing, browsing, debugging, and PDF Viewer documentation with current workflows and verification guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
