### PR TITLE
Keep web-tab zoom independent across same-origin tabs

### DIFF
--- a/docs/features/ZoomFeature.specs.md
+++ b/docs/features/ZoomFeature.specs.md
@@ -12,7 +12,10 @@ Zoom is applied to the active tab's `WebContentsView` using Electron's `webConte
 
 ## Requirements
 
-- Zoom changes must only occur when a tab is active.
+- Zoom changes target the active tab or its topmost sub-tab.
+- Every web tab uses Electron isolated zoom mode, including lazy/restored tabs and sub-tabs later adopted as normal tabs. Same-origin tabs retain independent zoom while sharing their existing cookies/session.
+- Zoom mode persists across navigation. Current zoom is published after loading, activation, creation/adoption and wheel input.
+- Built-in PDF reader zoom remains a separate document-level setting.
 - Zoom changes must be possible using Ctrl + mouse wheel.
 - Zoom level must be resettable via keyboard.
 - Zoom level must be clamped to a reasonable range.
@@ -38,7 +41,7 @@ This feature uses the following shortcuts:
 - **Ctrl+Plus (+)**: Zoom in.
 - **Ctrl+Minus (-)**: Zoom out.
 - **Ctrl+0**: Reset zoom level.
-- **Ctrl+MouseWheel**: Change zoom level (native Chromium behavior).
+- **Ctrl+MouseWheel**: Change zoom level (captured by the tab preload).
 
 ### Mouse interactions
 

--- a/docs/spec/implementation.md
+++ b/docs/spec/implementation.md
@@ -5,6 +5,7 @@
 - Use `BrowserWindow` with `WebContentsView` (not deprecated `BrowserView`)
 - Each tab = one `WebContentsView` attached to window
 - Tab switching = show/hide views, not destroy/create
+- Web tabs use `setZoomMode("isolated")`: zoom belongs to each WebContents, including sub-tabs and adopted contents, while cookies/session sharing is unchanged. Keyboard zoom targets the topmost sub-tab when open. PDF reader zoom is independent.
 - Multi-window support from day 1
 - **Per-tab session isolation**: Use `session.fromPartition('persist:tab-{id}')` for isolated tabs
   - Default: shared session

--- a/e2e/scenarios/zoom.spec.ts
+++ b/e2e/scenarios/zoom.spec.ts
@@ -1,0 +1,94 @@
+import type { DebugTarget } from "../../src/features/debug-server/targets.shared";
+import { startSite } from "../automation/site";
+import { expect, test } from "../fixtures/electron-app";
+import { VerificationPage } from "../pages/verification.page";
+
+test("same-origin tabs and sub-tabs keep independent zoom and shared sessions", async ({
+  appSession: session,
+}) => {
+  test.setTimeout(60_000);
+  const site = await startSite();
+  try {
+    const first = await VerificationPage.navigate(session, `${site.url}/first`);
+    const firstTarget = await session.target((t) => t.kind === "tab" && t.url.endsWith("/first"));
+    const baseline = await first.page.evaluate(() => devicePixelRatio);
+    await first.page.evaluate(() => {
+      // biome-ignore lint/suspicious/noDocumentCookie: exercise shared page cookies
+      document.cookie = "zoom-fixture=shared;path=/";
+    });
+    const key = async (target: DebugTarget, keyCode: string) => {
+      await session.app.evaluate(
+        ({ webContents }, { id, keyCode }) => {
+          const wc = webContents.fromId(id);
+          if (!wc) throw new Error("Missing target");
+          wc.sendInputEvent({ type: "keyDown", keyCode, modifiers: ["control"] });
+          wc.sendInputEvent({ type: "keyUp", keyCode, modifiers: ["control"] });
+        },
+        { id: target.webContentsId, keyCode },
+      );
+    };
+    const level = (target: DebugTarget) =>
+      session.app.evaluate(({ webContents }, id) => {
+        const wc = webContents.fromId(id);
+        if (!wc) throw new Error("Missing target");
+        return wc.getZoomLevel();
+      }, target.webContentsId);
+    await first.message.click();
+    await key(firstTarget, "=");
+    await expect.poll(() => level(firstTarget)).toBe(1);
+    await expect
+      .poll(() => first.page.evaluate(() => devicePixelRatio))
+      .toBeCloseTo(baseline * 1.2, 2);
+
+    const second = await VerificationPage.navigate(session, `${site.url}/second`);
+    const secondTarget = await session.target((t) => t.kind === "tab" && t.url.endsWith("/second"));
+    expect(await second.page.evaluate(() => document.cookie)).toContain("zoom-fixture=shared");
+    expect(await level(secondTarget)).toBe(0);
+    await second.message.hover();
+    const cursor = await session.eventCursor();
+    await second.page.keyboard.down("Control");
+    await second.page.mouse.wheel(0, -100);
+    await second.page.keyboard.up("Control");
+    expect((await session.waitForEvent("zoom:changed", cursor)).payload).toEqual({
+      tabId: secondTarget.tabId,
+      zoomLevel: 1,
+    });
+    await expect.poll(() => level(secondTarget)).toBe(1);
+    expect(await level(firstTarget)).toBe(1);
+    await key(secondTarget, "=");
+    await expect.poll(() => level(secondTarget)).toBe(2);
+    expect(await level(firstTarget)).toBe(1);
+
+    await second.subTab.click();
+    const childTarget = await session.target(
+      (t) => t.kind === "sub-tab" && t.url.endsWith("/child"),
+    );
+    const child = new VerificationPage(await session.page(childTarget));
+    await child.message.click();
+    expect(await level(childTarget)).toBe(0);
+    expect(await child.page.evaluate(() => document.cookie)).toContain("zoom-fixture=shared");
+    await key(childTarget, "-");
+    await expect.poll(() => level(childTarget)).toBe(-1);
+    expect(await level(secondTarget)).toBe(2);
+    await child.page.reload();
+    await expect.poll(() => level(childTarget)).toBe(-1);
+    const frame = await session.page(await session.target((t) => t.kind === "sub-tab-frame"));
+    const adoptedCursor = await session.eventCursor();
+    await frame.getByRole("button", { name: "Open as tab", exact: true }).click();
+    await session.waitForEvent("sub-tabs:promoted", adoptedCursor);
+    await session.target((t) => t.kind === "tab" && t.tabId === childTarget.tabId);
+    expect(await level(childTarget)).toBe(-1);
+    await key(childTarget, "0");
+    await expect.poll(() => level(childTarget)).toBe(0);
+    await session.shell.locator(`[data-tab-id="${firstTarget.tabId}"]`).click();
+    await expect.poll(() => level(firstTarget)).toBe(1);
+    await first.page.goto(`${site.url.replace("127.0.0.1", "localhost")}/navigated`);
+    await expect.poll(() => level(firstTarget)).toBe(1);
+    await key(firstTarget, "0");
+    await expect.poll(() => level(firstTarget)).toBe(0);
+    expect(await level(secondTarget)).toBe(2);
+    expect((await session.capture("isolated-zoom")).status).toBe("complete");
+  } finally {
+    await site.close();
+  }
+});

--- a/e2e/scenarios/zoom.spec.ts
+++ b/e2e/scenarios/zoom.spec.ts
@@ -8,6 +8,7 @@ test("same-origin tabs and sub-tabs keep independent zoom and shared sessions", 
 }) => {
   test.setTimeout(60_000);
   const site = await startSite();
+  const otherSite = await startSite();
   try {
     const first = await VerificationPage.navigate(session, `${site.url}/first`);
     const firstTarget = await session.target((t) => t.kind === "tab" && t.url.endsWith("/first"));
@@ -82,13 +83,13 @@ test("same-origin tabs and sub-tabs keep independent zoom and shared sessions", 
     await expect.poll(() => level(childTarget)).toBe(0);
     await session.shell.locator(`[data-tab-id="${firstTarget.tabId}"]`).click();
     await expect.poll(() => level(firstTarget)).toBe(1);
-    await first.page.goto(`${site.url.replace("127.0.0.1", "localhost")}/navigated`);
+    await first.page.goto(`${otherSite.url}/navigated`);
     await expect.poll(() => level(firstTarget)).toBe(1);
     await key(firstTarget, "0");
     await expect.poll(() => level(firstTarget)).toBe(0);
     expect(await level(secondTarget)).toBe(2);
     expect((await session.capture("isolated-zoom")).status).toBe("complete");
   } finally {
-    await site.close();
+    await Promise.all([site.close(), otherSite.close()]);
   }
 });

--- a/src/features/zoom/zoom.main.ts
+++ b/src/features/zoom/zoom.main.ts
@@ -5,9 +5,12 @@ import { defineFeature } from "../../shared/define-feature";
 import { logError } from "../../shared/log";
 import { TabScope } from "../../shared/tab-scope";
 import type { TabId } from "../../shared/types";
+import { SUB_TABS_CLOSED, SUB_TABS_OPENED, type SubTabsEvents } from "../sub-tabs/sub-tabs.shared";
 import {
+  TABS_ACTIVATED,
   TABS_CLOSED,
   TABS_CREATED,
+  type TabsActivatedEvent,
   type TabsClosedEvent,
   type TabsCreatedEvent,
 } from "../tabs/tabs.shared";
@@ -24,9 +27,12 @@ import {
   type ZoomEvents,
 } from "./zoom.shared";
 
-type AllEvents = ZoomEvents & { [K in typeof TABS_CREATED]: TabsCreatedEvent } & {
-  [K in typeof TABS_CLOSED]: TabsClosedEvent;
-};
+type AllEvents = ZoomEvents &
+  SubTabsEvents & { [K in typeof TABS_ACTIVATED]: TabsActivatedEvent } & {
+    [K in typeof TABS_CREATED]: TabsCreatedEvent;
+  } & {
+    [K in typeof TABS_CLOSED]: TabsClosedEvent;
+  };
 
 interface Deps {
   commands: CommandBus<ZoomCommands>;
@@ -98,16 +104,29 @@ export default defineFeature<Deps>({
     // the main process. This handler reads the already-applied level,
     // clamps if needed, and emits the bus event for UI updates.
 
-    events.on(TABS_CREATED, ({ tab }) => {
-      const cleanup = platform.onTabEvent(tab.id, "zoom-changed", () => {
-        const level = platform.getTabZoomLevel(tab.id);
+    function observeZoom(tabId: TabId) {
+      // Adoption reuses the contents and ID; replace the sub-tab subscription.
+      tabScope.cleanup(tabId);
+      const publishZoom = () => {
+        const level = platform.getTabZoomLevel(tabId);
         const clamped = clamp(level, ZOOM_MIN, ZOOM_MAX);
         if (clamped !== level) {
-          platform.setTabZoomLevel(tab.id, clamped);
+          platform.setTabZoomLevel(tabId, clamped);
         }
-        events.emit(ZOOM_CHANGED, { tabId: tab.id, zoomLevel: clamped });
-      });
-      tabScope.add(tab.id, cleanup);
+        events.emit(ZOOM_CHANGED, { tabId, zoomLevel: clamped });
+      };
+      tabScope.add(tabId, platform.onTabEvent(tabId, "zoom-changed", publishZoom));
+      tabScope.add(tabId, platform.onTabEvent(tabId, "did-finish-load", publishZoom));
+      publishZoom();
+    }
+
+    events.on(TABS_CREATED, ({ tab }) => observeZoom(tab.id));
+    events.on(SUB_TABS_OPENED, ({ subTab }) => observeZoom(subTab.id));
+    events.on(SUB_TABS_CLOSED, ({ subTabId }) => tabScope.cleanup(subTabId));
+    events.on(TABS_ACTIVATED, ({ tabId }) => {
+      const targetId = getActiveTabId() ?? tabId;
+      if (!targetId) return;
+      events.emit(ZOOM_CHANGED, { tabId: targetId, zoomLevel: platform.getTabZoomLevel(targetId) });
     });
 
     events.on(TABS_CLOSED, ({ tabId }) => {

--- a/src/features/zoom/zoom.test.ts
+++ b/src/features/zoom/zoom.test.ts
@@ -190,7 +190,7 @@ describe("Ctrl+MouseWheel (zoom-changed)", () => {
     const tab = makeTab({ id: "tab-new" as TabId });
     let onZoomChanged: (() => void) | undefined;
     vi.mocked(platform.onTabEvent).mockImplementation((_tabId, _event, cb) => {
-      onZoomChanged = cb as () => void;
+      if (_event === "zoom-changed") onZoomChanged = cb as () => void;
       return () => {};
     });
 
@@ -210,7 +210,7 @@ describe("Ctrl+MouseWheel (zoom-changed)", () => {
     const tab = makeTab({ id: "tab-new" as TabId });
     let onZoomChanged: (() => void) | undefined;
     vi.mocked(platform.onTabEvent).mockImplementation((_tabId, _event, cb) => {
-      onZoomChanged = cb as () => void;
+      if (_event === "zoom-changed") onZoomChanged = cb as () => void;
       return () => {};
     });
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -377,7 +377,17 @@ if (gotLock) {
     tooltip.register(deps);
     contextMenu.register(deps);
     folders.register({ ...deps, getTab, getTabsForWorkspace, setTabFolderId, setTabOrder });
-    zoom.register(deps);
+    zoom.register({
+      ...deps,
+      getActiveTabId: () => {
+        const parentId = deps.getActiveTabId();
+        return (
+          getSubTabSnapshot()
+            .filter((tab) => tab.parentTabId === parentId)
+            .at(-1)?.id ?? parentId
+        );
+      },
+    });
     devTools.register(deps);
     domainCss.register({ ...deps, dataDir, getTabsSnapshot: getAllTabs });
     downloads.register(deps);

--- a/src/platform/electron.ts
+++ b/src/platform/electron.ts
@@ -445,6 +445,10 @@ export class ElectronPlatform implements Platform {
       },
     });
 
+    // Keep zoom local to this WebContents without partitioning cookies/session.
+    // This also covers lazy tabs and sub-tabs that are later adopted.
+    view.webContents.setZoomMode("isolated");
+
     // Match the CSS border-radius of the content area (--radius = 0.5rem = 8px)
     view.setBorderRadius(8);
 


### PR DESCRIPTION
Web tabs now use Electron's isolated zoom mode, so tabs on the same origin can have different zoom levels while retaining their shared session and login cookies. Keyboard zoom targets the topmost sub-tab when present; zoom events cover sub-tabs, adoption, loading and activation.

Validation: full `bun run verify`, production build, and a native Windows regression covering keyboard zoom/reset, Ctrl+wheel, two same-origin tabs, a sub-tab, shared cookies, sub-tab promotion, tab activation and cross-origin navigation. Page scale is checked against Chromium's actual zoom. Custom PDF reader zoom remains independent.

Closes #41.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zoom now targets the active tab or topmost open sub-tab.
  * Web tabs and sub-tabs maintain independent zoom levels while sharing cookies and sessions.
  * Zoom settings persist across reloads and navigation.
  * Keyboard and Ctrl+MouseWheel controls work consistently.
  * PDF document zoom remains independent from web-content zoom.
* **Bug Fixes**
  * Zoom state updates correctly when tabs or sub-tabs are activated, created, closed, or promoted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->