### PR TITLE
Fix address-bar desktop input blocked by inactive Find bar

### DIFF
--- a/design-system/src/pages/components/address-bar.mdx
+++ b/design-system/src/pages/components/address-bar.mdx
@@ -17,7 +17,8 @@ The inactive Find bar is removed from layout. Opacity and `pointer-events: none`
 1. **Pill container** — rounded background housing URL and button
 2. **URL text** — monospace text with select-all behavior
 3. **Copy button** — icon-only button to copy URL to clipboard
-4. **Loading ring** — conic-gradient border animation shown during page load
+4. **Domain customization button** — sliders icon opening settings for the active web domain
+5. **Loading ring** — conic-gradient border animation shown during page load
 
 ---
 
@@ -49,11 +50,11 @@ The inactive Find bar is removed from layout. Opacity and `pointer-events: none`
 | Font size | `--text-sm` |
 | Color | `var(--glass-text-default)` |
 
-### Copy Button
+### Copy and Domain Customization Buttons
 
 | Property | Token/Value |
 |----------|-------------|
-| Size | `1.375rem x 1.375rem` |
+| Size | `24px x 24px` |
 | Border radius | `--radius-md` |
 | Default color | `var(--glass-text-muted)` |
 | Hover bg | `var(--glass-hover)` |
@@ -83,6 +84,8 @@ The inactive Find bar is removed from layout. Opacity and `pointer-events: none`
 
 ## Behavior
 
+- **Domain customization.** The sliders button is visible for HTTP(S) pages and opens the active domain’s settings. Its default, hover, and pressed colors follow the glass icon-button states; it has no copied-confirmation state.
+
 - **Select-all on focus.** When the URL bar gains focus, all text is selected so the user can immediately type a replacement.
 - **Monospace for URL display.** Uses `--font-mono` (JetBrains Mono) for the URL text.
 - **Copy to clipboard.** Copy button writes current URL to clipboard and shows check icon confirmation.
@@ -111,7 +114,7 @@ Uses `@property --url-angle` with a `conic-gradient` masked to the border edge. 
 
 ## Accessibility
 
-- **`aria-label`:** required on copy button (e.g., `aria-label="Copy URL"`).
+- **`aria-label`:** `Copy URL` on the copy button and `Domain customization` on the sliders button. Both are semantic buttons.
 - **Copy confirmation:** tooltip/`aria-live="polite"` announces "Copied" after clipboard write.
 - **Semantic HTML:** copy uses `<button type="button">`, URL text in a `<span>`.
 - **Touch target:** copy button meets `var(--click-target-min)` (1.375rem padded to 1.5rem).

--- a/design-system/src/pages/components/address-bar.mdx
+++ b/design-system/src/pages/components/address-bar.mdx
@@ -8,7 +8,9 @@ import { DEMO_TABS, makeDemoTabMap, tabId } from "../../lib/demo-data"
 
 # Address Bar
 
-The URL "pill" sits centered in the titlebar with an animated loading border and a copy button.
+The URL "pill" sits centered in the titlebar with an animated loading border, domain customization and copy buttons.
+
+The inactive Find bar is removed from layout. Opacity and `pointer-events: none` alone do not remove Electron native drag regions and can block these buttons on Windows. Icon centers and padding must remain hovered and clickable before and after using Find.
 
 ## Anatomy
 

--- a/docs/testing/agent-verification.md
+++ b/docs/testing/agent-verification.md
@@ -182,8 +182,7 @@ clipboard text and cleans up its own profile. It distinguishes the exact report
 (blocked icons with working padding), a broader failure (padding also blocked),
 no reproduction, and a failed positive control. Missing desktop screenshots are
 reported as partial evidence with a nonzero exit; renderer screenshots do not
-establish desktop composition. This is a diagnostic, not a passing regression
-test or a fix for #51, and it does not run in the regular CI suite.
+establish desktop composition. The diagnostic remains optional. `e2e/scenarios/address-bar.spec.ts` is the Windows regression for #51: icon/padding native clicks, hit tests, hover and command effects in restored and maximized windows, including after opening and closing Find.
 
 ### Remaining gaps
 

--- a/e2e/automation/windows-pointer.ts
+++ b/e2e/automation/windows-pointer.ts
@@ -53,7 +53,8 @@ export async function windowsPointer(
       native.handle,
       ...(click ? ["-Click"] : []),
     ],
-    { timeout: 5_000, windowsHide: true },
+    // Cold PowerShell/Add-Type startup can exceed five seconds on Windows CI.
+    { timeout: 15_000, windowsHide: true },
   );
   const observation = JSON.parse(result.stdout);
   session.record("windows-pointer", { point, click, ...observation });

--- a/e2e/pages/window-chrome.page.ts
+++ b/e2e/pages/window-chrome.page.ts
@@ -25,6 +25,14 @@ export class WindowChromePage {
     this.domainCssButton = page.locator("button[aria-label='Domain customization']");
   }
 
+  get findInput() {
+    return this.page.getByPlaceholder("Find in page");
+  }
+
+  addressBarButton(name: string) {
+    return this.page.getByRole("button", { name, exact: true });
+  }
+
   async isVisible(): Promise<boolean> {
     return this.titleBar.isVisible();
   }

--- a/e2e/scenarios/address-bar.spec.ts
+++ b/e2e/scenarios/address-bar.spec.ts
@@ -2,14 +2,16 @@ import { startSite } from "../automation/site";
 import { windowsPointer } from "../automation/windows-pointer";
 import { expect, test } from "../fixtures/electron-app";
 import { VerificationPage } from "../pages/verification.page";
+import { WindowChromePage } from "../pages/window-chrome.page";
 
 test("Windows address-bar native clicks in restored and maximized windows", async ({
   appSession: session,
 }) => {
   test.skip(process.platform !== "win32", "Requires Windows desktop hit testing");
-  test.setTimeout(60_000);
-  const site = await startSite();
+  test.setTimeout(300_000);
+  const chrome = new WindowChromePage(session.shell);
   const before = await session.app.evaluate(({ clipboard }) => clipboard.readText());
+  const site = await startSite();
   try {
     for (const maximized of [false, true]) {
       if (maximized)
@@ -20,52 +22,60 @@ test("Windows address-bar native clicks in restored and maximized windows", asyn
         });
       for (const name of ["Reload", "Copy URL", "Domain customization"]) {
         for (const part of ["icon", "padding"]) {
-          const url = `${site.url}/address-bar`;
-          await VerificationPage.navigate(session, url);
-          // Opening and closing Find must remove its native drag region as well as its UI.
-          await session.command("find:start");
-          const input = session.shell.getByPlaceholder("Find in page");
-          await expect(input).toBeFocused();
-          await input.press("Escape");
-          await expect(input).toHaveCount(0);
-          const button = session.shell.getByRole("button", {
-            name,
-            exact: true,
-          });
-          const box = await (part === "icon" ? button.locator("i") : button).boundingBox();
-          if (!box) throw new Error("Missing button geometry");
-          const point = {
-            x: box.x + (part === "icon" ? box.width / 2 : 2),
-            y: box.y + box.height / 2,
-          };
-          const native = await windowsPointer(session, point);
-          expect(native.hitTest).toBe(1);
-          await expect
-            .poll(() => button.evaluate((element) => element.matches(":hover")))
-            .toBe(true);
-          const cursor = await session.eventCursor();
-          await windowsPointer(session, point, true);
-          const command =
-            name === "Reload"
-              ? "window:reload"
-              : name === "Copy URL"
-                ? "window:copy-address"
-                : "domain-settings:open";
-          await expect
-            .poll(async () => {
-              const history = await session.debug<{
-                entries: { id: number; error?: string }[];
-              }>(`/history?type=command&name=${command}`);
-              return history.entries.some((entry) => entry.id > cursor && !entry.error);
-            })
-            .toBe(true);
-          if (name === "Copy URL")
-            expect(await session.app.evaluate(({ clipboard }) => clipboard.readText())).toBe(url);
+          await test.step(
+            `${maximized ? "maximized" : "restored"}: ${name} ${part}`,
+            async () => {
+              const url = `${site.url}/address-bar`;
+              await VerificationPage.navigate(session, url);
+              // Opening and closing Find must remove its native drag region as well as its UI.
+              await session.command("find:start");
+              const input = chrome.findInput;
+              await expect(input).toBeFocused();
+              await input.press("Escape");
+              await expect(input).toHaveCount(0);
+              const button = chrome.addressBarButton(name);
+              const box = await (part === "icon" ? button.locator("i") : button).boundingBox();
+              if (!box) throw new Error("Missing button geometry");
+              const point = {
+                x: box.x + (part === "icon" ? box.width / 2 : 2),
+                y: box.y + box.height / 2,
+              };
+              const native = await windowsPointer(session, point);
+              expect(native.hitTest).toBe(1);
+              await expect
+                .poll(() => button.evaluate((element) => element.matches(":hover")))
+                .toBe(true);
+              const cursor = await session.eventCursor();
+              await windowsPointer(session, point, true);
+              const command =
+                name === "Reload"
+                  ? "window:reload"
+                  : name === "Copy URL"
+                    ? "window:copy-address"
+                    : "domain-settings:open";
+              await expect
+                .poll(async () => {
+                  const history = await session.debug<{
+                    entries: { id: number; error?: string }[];
+                  }>(`/history?type=command&name=${command}`);
+                  return history.entries.some((entry) => entry.id > cursor && !entry.error);
+                })
+                .toBe(true);
+              if (name === "Copy URL")
+                expect(await session.app.evaluate(({ clipboard }) => clipboard.readText())).toBe(
+                  url,
+                );
+            },
+            { timeout: 60_000 },
+          );
         }
       }
     }
   } finally {
-    await session.app.evaluate(({ clipboard }, value) => clipboard.writeText(value), before);
-    await site.close();
+    try {
+      await session.app.evaluate(({ clipboard }, value) => clipboard.writeText(value), before);
+    } finally {
+      await site.close();
+    }
   }
 });

--- a/e2e/scenarios/address-bar.spec.ts
+++ b/e2e/scenarios/address-bar.spec.ts
@@ -1,0 +1,71 @@
+import { startSite } from "../automation/site";
+import { windowsPointer } from "../automation/windows-pointer";
+import { expect, test } from "../fixtures/electron-app";
+import { VerificationPage } from "../pages/verification.page";
+
+test("Windows address-bar native clicks in restored and maximized windows", async ({
+  appSession: session,
+}) => {
+  test.skip(process.platform !== "win32", "Requires Windows desktop hit testing");
+  test.setTimeout(60_000);
+  const site = await startSite();
+  const before = await session.app.evaluate(({ clipboard }) => clipboard.readText());
+  try {
+    for (const maximized of [false, true]) {
+      if (maximized)
+        await session.app.evaluate(({ BrowserWindow }) => {
+          BrowserWindow.getAllWindows()
+            .find((w) => !w.getParentWindow())
+            ?.maximize();
+        });
+      for (const name of ["Reload", "Copy URL", "Domain customization"]) {
+        for (const part of ["icon", "padding"]) {
+          const url = `${site.url}/address-bar`;
+          await VerificationPage.navigate(session, url);
+          // Opening and closing Find must remove its native drag region as well as its UI.
+          await session.command("find:start");
+          const input = session.shell.getByPlaceholder("Find in page");
+          await expect(input).toBeFocused();
+          await input.press("Escape");
+          await expect(input).toHaveCount(0);
+          const button = session.shell.getByRole("button", {
+            name,
+            exact: true,
+          });
+          const box = await (part === "icon" ? button.locator("i") : button).boundingBox();
+          if (!box) throw new Error("Missing button geometry");
+          const point = {
+            x: box.x + (part === "icon" ? box.width / 2 : 2),
+            y: box.y + box.height / 2,
+          };
+          const native = await windowsPointer(session, point);
+          expect(native.hitTest).toBe(1);
+          await expect
+            .poll(() => button.evaluate((element) => element.matches(":hover")))
+            .toBe(true);
+          const cursor = await session.eventCursor();
+          await windowsPointer(session, point, true);
+          const command =
+            name === "Reload"
+              ? "window:reload"
+              : name === "Copy URL"
+                ? "window:copy-address"
+                : "domain-settings:open";
+          await expect
+            .poll(async () => {
+              const history = await session.debug<{
+                entries: { id: number; error?: string }[];
+              }>(`/history?type=command&name=${command}`);
+              return history.entries.some((entry) => entry.id > cursor && !entry.error);
+            })
+            .toBe(true);
+          if (name === "Copy URL")
+            expect(await session.app.evaluate(({ clipboard }) => clipboard.readText())).toBe(url);
+        }
+      }
+    }
+  } finally {
+    await session.app.evaluate(({ clipboard }, value) => clipboard.writeText(value), before);
+    await site.close();
+  }
+});

--- a/src/features/find-text/find-text.renderer.tsx
+++ b/src/features/find-text/find-text.renderer.tsx
@@ -89,16 +89,7 @@ export function FindBar() {
   if (!active) return null;
 
   return (
-    <div
-      className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
-      style={{
-        transition:
-          "opacity var(--duration-normal) var(--ease-out), scale var(--duration-normal) var(--ease-out)",
-        opacity: active ? 1 : 0,
-        scale: active ? "1" : "0.96",
-        pointerEvents: active ? "auto" : "none",
-      }}
-    >
+    <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
       <div
         className="relative flex items-center"
         style={
@@ -110,7 +101,7 @@ export function FindBar() {
             padding: "0.1875rem 0.25rem",
             borderRadius: "var(--radius-lg)",
             background: "var(--glass-subtle)",
-            WebkitAppRegion: active ? "no-drag" : undefined,
+            WebkitAppRegion: "no-drag",
           } as React.CSSProperties
         }
       >

--- a/src/features/find-text/find-text.renderer.tsx
+++ b/src/features/find-text/find-text.renderer.tsx
@@ -84,6 +84,10 @@ export function FindBar() {
       "background-color var(--duration-fast) var(--ease-out), color var(--duration-fast) var(--ease-out)",
   };
 
+  // Opacity/pointer-events do not remove native draggable regions.
+  // An invisible find bar can otherwise cover the address-bar buttons.
+  if (!active) return null;
+
   return (
     <div
       className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"


### PR DESCRIPTION
An inactive Find bar retained an Electron draggable region over the address bar. Copy URL and Domain customization therefore received neither hover nor clicks from the Windows pointer, although CDP clicks worked.

Unmount the inactive Find bar so its native drag region is removed. The address-bar layout remains intact. Add a Windows regression covering icon centers and button padding for Reload, Copy URL, and Domain customization in restored and maximized windows, including after opening and closing Find.

Validation: full `bun run verify`, application and design-system builds pass. Native Windows regression passes; before/after icon-and-padding diagnostics show the blocked controls changing from HTCAPTION to HTCLIENT with working hover, command activation, and clipboard contents. Inspected renderer hover evidence in both window modes.

Closes #51.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Inactive Find bars no longer block address-bar buttons or draggable regions.
  - Address-bar interactions now work correctly in restored and maximized Windows windows.
  - Improved native hit testing, hover behavior, icon alignment, padding, and click handling.

- **Tests**
  - Added Windows end-to-end coverage for address-bar interactions, Find behavior, command history, and clipboard results.

- **Documentation**
  - Updated address-bar guidance for domain customization and accessibility.
  - Documented Windows regression coverage for address-bar diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->