### PR TITLE
Add Duplicate tab with preserved navigation history

### DIFF
--- a/design-system/src/pages/components/pinned-tabs.mdx
+++ b/design-system/src/pages/components/pinned-tabs.mdx
@@ -134,3 +134,9 @@ Horizontal strip of favicon-only buttons for globally pinned tabs. Always visibl
 - [Sidebar](/components/sidebar) — parent container
 - [Tabs](/components/tabs) — regular tab items in the sidebar list
 - [Workspace Switcher](/components/workspace-switcher) — sits at sidebar bottom
+
+### Duplicate tab
+
+The `PinnedTabsStrip` context menu includes **Duplicate tab** for loaded web tabs.
+The copy is an active ephemeral tab in the current workspace; the source remains
+pinned. Built-in/PDF tabs and pins without a live tab disable the action.

--- a/design-system/src/pages/components/tabs.mdx
+++ b/design-system/src/pages/components/tabs.mdx
@@ -93,3 +93,10 @@ Three tab types exist with different default text brightness:
 - [Sidebar](/components/sidebar) — parent container
 - [Buttons](/components/buttons) — close button pattern
 - [Tooltips](/components/tooltips) — shown on truncated labels and close buttons
+
+### Duplicate tab
+
+`TabItem` exposes **Duplicate tab** in its native context menu. The action creates
+an active ephemeral tab in the source workspace, preserving web history, session,
+and zoom. It is disabled for built-in pages and PDF reader tabs. Bookmark and tab
+customization settings remain with the source.

--- a/design-system/src/pages/components/tabs.mdx
+++ b/design-system/src/pages/components/tabs.mdx
@@ -97,6 +97,7 @@ Three tab types exist with different default text brightness:
 ### Duplicate tab
 
 `TabItem` exposes **Duplicate tab** in its native context menu. The action creates
-an active ephemeral tab in the source workspace, preserving web history, session,
-and zoom. It is disabled for built-in pages and PDF reader tabs. Bookmark and tab
+an ephemeral tab in the source workspace, preserving web history, session,
+and zoom. Copies in the active workspace activate immediately; commands targeting
+an inactive workspace create background copies there. It is disabled for built-in pages and PDF reader tabs. Bookmark and tab
 customization settings remain with the source.

--- a/docs/features/TabsFeature.specs.md
+++ b/docs/features/TabsFeature.specs.md
@@ -119,3 +119,21 @@ In the Sidebar tab list:
 - **Tab memory management**: SPEC.md mentions lazy-loading tabs and limiting concurrent WebContentsViews. This spec doesn't define the eviction/hibernation policy for tabs when memory is constrained.
 - **Session isolation**: SPEC.md mentions per-tab session isolation via `session.fromPartition()`. This spec doesn't address how isolated sessions interact with bookmarked/ephemeral tab lifecycle.
 - **New tab behavior**: When creating a tab from the command palette, should it default to ephemeral? The spec doesn't define the default tab type for new tabs.
+
+### Duplicate tab
+
+Right-click a normal, bookmarked, or pinned web tab and choose **Duplicate tab**
+(`tabs:duplicate`, `{ tabId }`). The copy is ephemeral and belongs to the
+source workspace (global pinned tabs duplicate into the current workspace); it does not copy a bookmark, pin, folder assignment, or tab
+customization. Chromium's cloned navigation controller retains back and forward
+history and the current entry. The current page reloads, creating a fresh DOM and
+JavaScript heap. The source session and current zoom are preserved, with subsequent
+zoom and navigation independent in each tab. Both contents use the normal platform
+listeners, navigation guards, permissions, shortcuts, and cleanup.
+
+A restored but unloaded source has only its persisted URL available, so the copy
+loads that URL. Built-in pages and PDF reader tabs have no web navigation controller:
+the menu item is disabled and the command returns no tab. Missing sources also
+return no tab; native cloning errors leave the source unchanged. Copies in the
+current workspace activate immediately. A command targeting a non-pinned tab in
+an inactive workspace creates its copy there in the background.

--- a/e2e/scenarios/duplicate-tab.spec.ts
+++ b/e2e/scenarios/duplicate-tab.spec.ts
@@ -1,0 +1,199 @@
+import { startSite } from "../automation/site";
+import { expect, test } from "../fixtures/electron-app";
+import { VerificationPage } from "../pages/verification.page";
+
+test("Duplicate tab preserves history, session and zoom with independent lifecycle", async ({
+  appSession: session,
+}) => {
+  test.setTimeout(60_000);
+  const site = await startSite();
+  const other = await startSite();
+  try {
+    const original = await VerificationPage.navigate(session, `${site.url}/first`);
+    await original.page.goto(`${site.url}/second`);
+    await original.page.goto(`${other.url}/third`);
+    await original.page.goBack();
+    await original.submit("live heap stays in source");
+    const source = await session.target((t) => t.kind === "tab" && t.url === `${site.url}/second`);
+    const history = (id: number) =>
+      session.app.evaluate(({ webContents }, id) => {
+        const wc = webContents.fromId(id);
+        if (!wc) throw new Error("Missing tab");
+        return {
+          entries: wc.navigationHistory.getAllEntries().map((e) => e.url),
+          index: wc.navigationHistory.getActiveIndex(),
+        };
+      }, id);
+    await session.app.evaluate(async ({ webContents }, id) => {
+      const wc = webContents.fromId(id);
+      if (!wc) throw new Error("Missing source");
+      wc.setZoomLevel(2);
+      await wc.session.cookies.set({
+        url: wc.getURL(),
+        name: "duplicate-fixture",
+        value: "shared",
+      });
+    }, source.webContentsId);
+    const before = await history(source.webContentsId);
+    // Native menus have no CDP target. Inspect the actual menu and invoke its item callback.
+    await session.app.evaluate(({ Menu }) => {
+      const original = Menu.prototype.popup;
+      Menu.prototype.popup = function (options) {
+        (globalThis as typeof globalThis & { verificationMenu?: Electron.Menu }).verificationMenu =
+          this;
+        Menu.prototype.popup = original;
+        return original.call(this, options);
+      };
+    });
+    await session.shell.locator(`[data-tab-id="${source.tabId}"]`).click({ button: "right" });
+    await expect
+      .poll(() =>
+        session.app.evaluate(() => {
+          const menu = (globalThis as typeof globalThis & { verificationMenu?: Electron.Menu })
+            .verificationMenu;
+          return menu?.items.some((item) => item.label === "Duplicate tab" && item.enabled);
+        }),
+      )
+      .toBe(true);
+    expect((await session.capture("duplicate-tab-menu")).status).toBe("complete");
+    await session.app.evaluate(() => {
+      const root = globalThis as typeof globalThis & { verificationMenu?: Electron.Menu };
+      const menu = root.verificationMenu!;
+      const item = menu.items.find((item) => item.label === "Duplicate tab")!;
+      item.click();
+      menu.closePopup();
+      delete root.verificationMenu;
+    });
+    const clone = await session.target(
+      (t) => t.kind === "tab" && t.tabId !== source.tabId && t.url === source.url,
+    );
+    const copy = new VerificationPage(await session.page(clone));
+    await expect(copy.message).toBeVisible();
+    expect(await history(clone.webContentsId)).toEqual(before);
+    await expect(copy.result).toHaveText("");
+    await expect(original.result).toHaveText("live heap stays in source");
+    expect(
+      await session.app.evaluate(
+        ({ webContents }, { a, b }) => {
+          const source = webContents.fromId(a)!;
+          const clone = webContents.fromId(b)!;
+          return {
+            sameSession: source.session === clone.session,
+            zoom: clone.getZoomLevel(),
+            mode: clone.getZoomMode(),
+          };
+        },
+        { a: source.webContentsId, b: clone.webContentsId },
+      ),
+    ).toEqual({ sameSession: true, zoom: 2, mode: "isolated" });
+    expect(await copy.page.evaluate(() => document.cookie)).toContain("duplicate-fixture=shared");
+    await copy.page.goForward();
+    await expect(copy.page).toHaveURL(`${other.url}/third`);
+    expect(await history(source.webContentsId)).toEqual(before);
+    await copy.page.goBack();
+    await copy.page.goBack();
+    await expect(copy.page).toHaveURL(`${site.url}/first`);
+    await session.command("zoom:in");
+    expect(
+      await session.app.evaluate(
+        ({ webContents }, id) => webContents.fromId(id)?.getZoomLevel(),
+        source.webContentsId,
+      ),
+    ).toBe(2);
+    const disposable = await session.command<string>("tabs:duplicate", { tabId: source.tabId });
+    await session.target((t) => t.kind === "tab" && t.tabId === disposable);
+    await session.command("tabs:close", { tabId: disposable });
+    expect(await history(source.webContentsId)).toEqual(before);
+    await session.command("tabs:activate", { tabId: source.tabId });
+    await original.message.fill("");
+    await original.submit("source survives closing a copy");
+    await expect(original.result).toHaveText("source survives closing a copy");
+    await session.command("tabs:activate", { tabId: clone.tabId });
+    await session.command("tabs:close", { tabId: source.tabId });
+    await copy.submit("copy survives");
+    await expect(copy.result).toHaveText("copy survives");
+    await copy.subTab.click();
+    await session.target((t) => t.kind === "sub-tab" && t.url.endsWith("/child"));
+    await session.command("sub-tabs:close", { parentTabId: clone.tabId });
+    expect((await session.capture("duplicate-tab")).status).toBe("complete");
+  } finally {
+    await Promise.all([site.close(), other.close()]);
+  }
+});
+
+test("cloned tab views retain isolated sessions and web preferences", async ({
+  appSession: session,
+}) => {
+  const { build } = await import("esbuild");
+  const path = await import("node:path");
+  const fs = await import("node:fs/promises");
+  // Exercise the same view factory with a non-default source session. Workspaces currently
+  // control persistence, not Chromium partitions; this checks the native boundary explicitly.
+  const filename = path.resolve("out/main/verify-tab-view.cjs");
+  await build({
+    entryPoints: ["src/platform/tab-view.ts"],
+    outfile: filename,
+    bundle: true,
+    platform: "node",
+    format: "cjs",
+    external: ["electron"],
+  });
+  const site = await startSite();
+  try {
+    const result = await session.app.evaluate(
+      async ({ session, WebContentsView }, { filename, url }) => {
+        const { createTabView } = process.getBuiltinModule("module").createRequire(filename)(
+          filename,
+        ) as {
+          createTabView(source: Electron.WebContents): Electron.WebContentsView;
+        };
+        const isolated = session.fromPartition(`duplicate-${crypto.randomUUID()}`);
+        const source = new WebContentsView({
+          webPreferences: {
+            session: isolated,
+            sandbox: true,
+            contextIsolation: true,
+            nodeIntegration: false,
+            spellcheck: false,
+          },
+        });
+        let copy: Electron.WebContentsView | undefined;
+        try {
+          await isolated.cookies.set({ url, name: "isolated-duplicate", value: "private" });
+          await source.webContents.loadURL(url);
+          copy = createTabView(source.webContents);
+          const loaded = new Promise<void>((resolve) =>
+            copy!.webContents.once("did-finish-load", () => resolve()),
+          );
+          copy.webContents.reload();
+          await loaded;
+          return {
+            sameSession: copy.webContents.session === isolated,
+            differentFromDefault: copy.webContents.session !== session.defaultSession,
+            copiedCookie: (
+              await copy.webContents.session.cookies.get({ url, name: "isolated-duplicate" })
+            ).length,
+            defaultCookie: (
+              await session.defaultSession.cookies.get({ url, name: "isolated-duplicate" })
+            ).length,
+            nodeAccess: await copy.webContents.executeJavaScript("typeof require"),
+          };
+        } finally {
+          await copy?.webContents.close();
+          await source.webContents.close();
+        }
+      },
+      { filename, url: `${site.url}/isolated` },
+    );
+    expect(result).toMatchObject({
+      sameSession: true,
+      differentFromDefault: true,
+      copiedCookie: 1,
+      defaultCookie: 0,
+      nodeAccess: "undefined",
+    });
+  } finally {
+    await site.close();
+    await fs.unlink(filename);
+  }
+});

--- a/e2e/scenarios/duplicate-tab.spec.ts
+++ b/e2e/scenarios/duplicate-tab.spec.ts
@@ -114,7 +114,10 @@ test("Duplicate tab preserves history, session and zoom with independent lifecyc
     await expect(copy.result).toHaveText("copy survives");
     await copy.subTab.click();
     await session.target((t) => t.kind === "sub-tab" && t.url.endsWith("/child"));
-    await session.command("sub-tabs:close", { parentTabId: clone.tabId });
+    const frame = await session.page(await session.target((t) => t.kind === "sub-tab-frame"));
+    const closed = await session.eventCursor();
+    await frame.getByRole("button", { name: "Close sub-tab", exact: true }).click();
+    await session.waitForEvent("sub-tabs:closed", closed);
     expect((await session.capture("duplicate-tab")).status).toBe("complete");
   } finally {
     await Promise.all([site.close(), other.close()]);

--- a/src/features/sidebar/PinnedTabsStrip.tsx
+++ b/src/features/sidebar/PinnedTabsStrip.tsx
@@ -8,12 +8,15 @@ import {
 } from "../tab-customization/tab-customization.shared";
 import { useTabCustomizationStore } from "../tab-customization/tab-customization.store";
 import type { Tab, TabsCommands } from "../tabs/tabs.shared";
-import { TABS_CLOSE, TABS_NAVIGATE } from "../tabs/tabs.shared";
+import { canDuplicateTab, TABS_CLOSE, TABS_DUPLICATE, TABS_NAVIGATE } from "../tabs/tabs.shared";
 import { Favicon } from "./Favicon";
 
 // ── Typed sendCommand ───────────────────────────────────────────
 
-type PinnedUsedCommands = Pick<TabsCommands, typeof TABS_CLOSE | typeof TABS_NAVIGATE> &
+type PinnedUsedCommands = Pick<
+  TabsCommands,
+  typeof TABS_CLOSE | typeof TABS_NAVIGATE | typeof TABS_DUPLICATE
+> &
   Pick<PinnedTabsCommands, typeof PINNED_TABS_ACTIVATE | typeof PINNED_TABS_TOGGLE_PIN> &
   Pick<TabCustomizationCommands, typeof TAB_CUSTOMIZATION_OPEN>;
 
@@ -41,7 +44,14 @@ function PinnedTabButton({
   const displayTitle = customTitle || pt.title || pt.url;
   const handleContextMenu = (e: React.MouseEvent) => {
     if (!onContextMenu) return;
-    const items: ContextMenuItem[] = [];
+    const items: ContextMenuItem[] = [
+      {
+        label: "Duplicate tab",
+        icon: "copy",
+        disabled: !canDuplicateTab(tab),
+        onSelect: () => sendCommand(TABS_DUPLICATE, { tabId: pt.id }),
+      },
+    ];
     items.push(
       {
         label: "Unpin tab",

--- a/src/features/sidebar/TabItem.tsx
+++ b/src/features/sidebar/TabItem.tsx
@@ -11,8 +11,10 @@ import {
 import { useTabCustomizationStore } from "../tab-customization/tab-customization.store";
 import type { Tab, TabsCommands } from "../tabs/tabs.shared";
 import {
+  canDuplicateTab,
   TABS_ACTIVATE,
   TABS_CLOSE,
+  TABS_DUPLICATE,
   TABS_NAVIGATE,
   TABS_REORDER,
   TABS_TOGGLE_BOOKMARK,
@@ -25,6 +27,7 @@ import { useSidebarDrag } from "./SidebarContext";
 type TabItemUsedCommands = Pick<
   TabsCommands,
   | typeof TABS_ACTIVATE
+  | typeof TABS_DUPLICATE
   | typeof TABS_CLOSE
   | typeof TABS_NAVIGATE
   | typeof TABS_REORDER
@@ -97,7 +100,14 @@ export function TabItem({
 
   const handleContextMenu = (e: React.MouseEvent) => {
     if (!onContextMenu) return;
-    const items: ContextMenuItem[] = [];
+    const items: ContextMenuItem[] = [
+      {
+        label: "Duplicate tab",
+        icon: "copy",
+        disabled: !canDuplicateTab(tab),
+        onSelect: () => sendCommand(TABS_DUPLICATE, { tabId: tab.id }),
+      },
+    ];
     if (isEphemeral) {
       items.push({
         label: "Bookmark",

--- a/src/features/tabs/tabs.main.ts
+++ b/src/features/tabs/tabs.main.ts
@@ -12,6 +12,7 @@ import type {
   TabLoadingChangedPayload,
 } from "../window-chrome/window-chrome.shared";
 import {
+  canDuplicateTab,
   type PersistedTab,
   TABS_ACTIVATE,
   TABS_ACTIVATED,
@@ -22,6 +23,7 @@ import {
   TABS_CONTENT_BOUNDS_CHANGED,
   TABS_CREATE,
   TABS_CREATED,
+  TABS_DUPLICATE,
   TABS_GET,
   TABS_GET_FOR_WORKSPACE,
   TABS_LIST_CHANGED,
@@ -362,6 +364,43 @@ export default defineFeature<Deps>({
         await commands.send(TABS_ACTIVATE, { tabId });
       }
 
+      return tabId;
+    });
+
+    commands.handle(TABS_DUPLICATE, async ({ tabId: sourceId }) => {
+      const source = tabs.get(sourceId);
+      if (!source || !canDuplicateTab(source)) return undefined;
+      const windowId = getActiveWindowId();
+      if (!windowId) throw new Error("No active window");
+      const tabId = await platform.createTab(windowId, source.url, undefined, {
+        cloneFrom: sourceId,
+      });
+      const workspaceId = isPinned(sourceId)
+        ? (getActiveWorkspaceId() ?? source.workspaceId)
+        : source.workspaceId;
+      const now = Date.now();
+      const tab: Tab = {
+        id: tabId,
+        workspaceId,
+        url: source.url,
+        title: source.title,
+        favicon: source.favicon,
+        loading: true,
+        bookmarked: false,
+        lastAccessedAt: now,
+        createdAt: now,
+        order: tabs.size,
+        folderId: null,
+      };
+      tabs.set(tabId, tab);
+      attachTabListeners(tabId);
+      persistTab(tab);
+      events.emit(TABS_CREATED, { tab });
+      events.emit("tab:loading-changed", { tabId, loading: true });
+      scheduleListChanged();
+      if (workspaceId === getActiveWorkspaceId()) {
+        await commands.send(TABS_ACTIVATE, { tabId });
+      }
       return tabId;
     });
 

--- a/src/features/tabs/tabs.shared.ts
+++ b/src/features/tabs/tabs.shared.ts
@@ -2,6 +2,7 @@ import type { Bounds, FolderId, TabId, WorkspaceId } from "../../shared/types";
 
 // ── Command names ────────────────────────────────────────────────
 export const TABS_CREATE = "tabs:create" as const;
+export const TABS_DUPLICATE = "tabs:duplicate" as const;
 export const TABS_CLOSE = "tabs:close" as const;
 export const TABS_ACTIVATE = "tabs:activate" as const;
 export const TABS_NAVIGATE = "tabs:navigate" as const;
@@ -127,6 +128,7 @@ export interface TabsListChangedEvent {
 // ── Command registry ─────────────────────────────────────────────
 export type TabsCommands = {
   [TABS_CREATE]: { payload: TabsCreatePayload; response: TabId };
+  [TABS_DUPLICATE]: { payload: { tabId: TabId }; response: TabId | undefined };
   [TABS_CLOSE]: { payload: TabsClosePayload; response: undefined };
   [TABS_ACTIVATE]: { payload: TabsActivatePayload; response: undefined };
   [TABS_NAVIGATE]: { payload: TabsNavigatePayload; response: undefined };
@@ -157,3 +159,8 @@ export type TabsEvents = {
   [TABS_LIST_CHANGED]: TabsListChangedEvent;
   [TABS_CONTENT_BOUNDS_CHANGED]: Bounds;
 };
+
+/** Built-in renderers (including PDFs) have no independent web history to clone. */
+export function canDuplicateTab(tab: Tab | undefined): boolean {
+  return !!tab && !tab.builtIn && !tab.url.startsWith("app:");
+}

--- a/src/features/tabs/tabs.test.ts
+++ b/src/features/tabs/tabs.test.ts
@@ -25,6 +25,8 @@ import {
   TABS_CLOSED,
   TABS_CREATE,
   TABS_CREATED,
+  TABS_DUPLICATE,
+  TABS_GET,
   TABS_LIST_CHANGED,
   TABS_NAVIGATE,
   TABS_REORDER,
@@ -83,6 +85,69 @@ describe("tabs commands", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  describe("TABS_DUPLICATE", () => {
+    it("creates a background copy in an inactive source workspace without changing its bookmark", async () => {
+      const { commands, platform, getActiveTabId } = setup();
+      const sourceId = await commands.send(TABS_CREATE, {
+        url: "https://example.com",
+        workspaceId: "other-workspace" as WorkspaceId,
+      });
+      await commands.send(TABS_TOGGLE_BOOKMARK, { tabId: sourceId });
+      const copyId = await commands.send(TABS_DUPLICATE, { tabId: sourceId });
+      expect(platform.createTab).toHaveBeenLastCalledWith(
+        WIN_ID,
+        "https://example.com",
+        undefined,
+        { cloneFrom: sourceId },
+      );
+      expect(getActiveTabId()).toBe(sourceId);
+      expect(await commands.send(TABS_GET, { tabId: copyId! })).toMatchObject({
+        workspaceId: "other-workspace",
+        bookmarked: false,
+        folderId: null,
+      });
+      expect(await commands.send(TABS_GET, { tabId: sourceId })).toMatchObject({
+        bookmarked: true,
+      });
+    });
+
+    it("duplicates global pins into the current workspace and activates the copy", async () => {
+      const { commands, getActiveTabId } = setup();
+      const tabId = await commands.send(TABS_CREATE, {
+        url: "https://example.com",
+        workspaceId: "other" as WorkspaceId,
+      });
+      vi.mocked(isPinned).mockReturnValue(true);
+      const copyId = await commands.send(TABS_DUPLICATE, { tabId });
+      expect(getActiveTabId()).toBe(copyId);
+      expect(await commands.send(TABS_GET, { tabId: copyId! })).toMatchObject({
+        workspaceId: WS_ID,
+        bookmarked: false,
+      });
+    });
+
+    it("ignores missing, built-in and PDF sources without creating contents", async () => {
+      const { commands, platform } = setup();
+      for (const url of ["app:settings", "app:pdf?file=fixture.pdf"]) {
+        const tabId = await commands.send(TABS_CREATE, { url });
+        expect(await commands.send(TABS_DUPLICATE, { tabId })).toBeUndefined();
+      }
+      expect(await commands.send(TABS_DUPLICATE, { tabId: "missing" as TabId })).toBeUndefined();
+      expect(platform.createTab).not.toHaveBeenCalled();
+    });
+
+    it("leaves the source active and unchanged when native cloning fails", async () => {
+      const { commands, platform, getActiveTabId } = setup();
+      const tabId = await commands.send(TABS_CREATE, { url: "https://example.com" });
+      vi.mocked(platform.createTab).mockRejectedValueOnce(new Error("clone failed"));
+      await expect(commands.send(TABS_DUPLICATE, { tabId })).rejects.toThrow("clone failed");
+      expect(getActiveTabId()).toBe(tabId);
+      expect(await commands.send(TABS_GET, { tabId })).toMatchObject({
+        url: "https://example.com",
+      });
+    });
   });
 
   describe("TABS_CREATE", () => {

--- a/src/platform/electron.ts
+++ b/src/platform/electron.ts
@@ -12,10 +12,11 @@ import {
   screen,
   session,
   shell,
-  WebContentsView,
+  type WebContentsView,
   webContents,
 } from "electron";
 import type { Bounds, TabId, WindowId } from "../shared/types";
+import { createTabView } from "./tab-view";
 import type { Platform, PlatformDownload } from "./types";
 
 const ALLOWED_SCHEMES_WEB = new Set(["http:", "https:", "about:", "data:"]);
@@ -429,25 +430,18 @@ export class ElectronPlatform implements Platform {
     windowId: WindowId,
     url: string,
     existingTabId?: TabId,
-    options?: { lazy?: boolean },
+    options?: { lazy?: boolean; cloneFrom?: TabId },
   ): Promise<TabId> {
     const win = this.getWin(windowId);
     if (!win) throw new Error("No window found");
 
+    const source = options?.cloneFrom ? this.views.get(options.cloneFrom)?.webContents : undefined;
+    if (options?.cloneFrom && (!source || source.isDestroyed())) {
+      throw new Error("Cannot duplicate a missing tab");
+    }
+    if (!isAllowedUrl(url, "internal")) throw new Error(`Blocked URL scheme: ${url}`);
     const tabId = existingTabId ?? (crypto.randomUUID() as TabId);
-    const view = new WebContentsView({
-      webPreferences: {
-        sandbox: true,
-        contextIsolation: true,
-        nodeIntegration: false,
-        webSecurity: true,
-        preload: path.join(__dirname, "../preload/tab.js"),
-      },
-    });
-
-    // Keep zoom local to this WebContents without partitioning cookies/session.
-    // This also covers lazy tabs and sub-tabs that are later adopted.
-    view.webContents.setZoomMode("isolated");
+    const view = createTabView(source);
 
     // Match the CSS border-radius of the content area (--radius = 0.5rem = 8px)
     view.setBorderRadius(8);
@@ -602,8 +596,10 @@ export class ElectronPlatform implements Platform {
     }
 
     if (!options?.lazy) {
-      if (!isAllowedUrl(url, "internal")) throw new Error(`Blocked URL scheme: ${url}`);
-      view.webContents.loadURL(url);
+      // Reload the cloned controller entry without appending a URL or losing forward history.
+      // A restored, unloaded source has no native history yet.
+      if (source?.getURL()) view.webContents.reload();
+      else view.webContents.loadURL(url);
     }
 
     return tabId;

--- a/src/platform/tab-view.test.ts
+++ b/src/platform/tab-view.test.ts
@@ -1,0 +1,37 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  WebContentsView: class {
+    webContents: unknown;
+    constructor(options: { webContents: unknown }) {
+      this.webContents = options.webContents;
+    }
+  },
+}));
+
+import { createTabView } from "./tab-view";
+
+describe("cloned tab initialization", () => {
+  it("restores zoom on main-frame failure and stops restoring after the initial load", () => {
+    const contents = Object.assign(new EventEmitter(), {
+      setZoomMode: vi.fn(),
+      setZoomLevel: vi.fn(),
+    });
+    const source = {
+      clone: () => contents,
+      getZoomLevel: () => 2,
+    } as unknown as Electron.WebContents;
+    createTabView(source);
+    contents.emit("did-fail-load", {}, -105, "Failed", "https://example.com/frame", false);
+    expect(contents.setZoomLevel).not.toHaveBeenCalled();
+    contents.emit("did-fail-load", {}, -105, "Failed", "https://example.com", true);
+    expect(contents.setZoomLevel).toHaveBeenLastCalledWith(2);
+    contents.emit("did-finish-load");
+    contents.emit("did-stop-loading");
+    contents.setZoomLevel.mockClear();
+    contents.emit("did-fail-load", {}, -105, "Failed", "https://example.com", true);
+    contents.emit("did-finish-load");
+    expect(contents.setZoomLevel).not.toHaveBeenCalled();
+  });
+});

--- a/src/platform/tab-view.ts
+++ b/src/platform/tab-view.ts
@@ -1,0 +1,26 @@
+import path from "node:path";
+import { type WebContents, WebContentsView } from "electron";
+
+/** Construct normal and duplicated tabs without replacing a clone's session or preferences. */
+export function createTabView(source?: WebContents): WebContentsView {
+  const view = source
+    ? new WebContentsView({ webContents: source.clone() })
+    : new WebContentsView({
+        webPreferences: {
+          sandbox: true,
+          contextIsolation: true,
+          nodeIntegration: false,
+          webSecurity: true,
+          preload: path.join(__dirname, "../preload/tab.js"),
+        },
+      });
+  // Isolate zoom without partitioning the session's cookies or storage.
+  view.webContents.setZoomMode("isolated");
+  if (source) {
+    const zoomLevel = source.getZoomLevel();
+    // First renderer initialization resets isolated zoom. Restore before feature listeners
+    // publish did-finish-load, then allow each copy to zoom independently.
+    view.webContents.once("did-finish-load", () => view.webContents.setZoomLevel(zoomLevel));
+  }
+  return view;
+}

--- a/src/platform/tab-view.ts
+++ b/src/platform/tab-view.ts
@@ -20,7 +20,23 @@ export function createTabView(source?: WebContents): WebContentsView {
     const zoomLevel = source.getZoomLevel();
     // First renderer initialization resets isolated zoom. Restore before feature listeners
     // publish did-finish-load, then allow each copy to zoom independently.
-    view.webContents.once("did-finish-load", () => view.webContents.setZoomLevel(zoomLevel));
+    const contents = view.webContents;
+    const restoreZoom = () => contents.setZoomLevel(zoomLevel);
+    const failed = (
+      _event: Electron.Event,
+      _code: number,
+      _description: string,
+      _url: string,
+      isMainFrame: boolean,
+    ) => {
+      if (isMainFrame) restoreZoom();
+    };
+    contents.on("did-finish-load", restoreZoom);
+    contents.on("did-fail-load", failed);
+    contents.once("did-stop-loading", () => {
+      contents.removeListener("did-finish-load", restoreZoom);
+      contents.removeListener("did-fail-load", failed);
+    });
   }
   return view;
 }

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -36,7 +36,7 @@ export interface Platform {
     windowId: WindowId,
     url: string,
     tabId?: TabId,
-    options?: { lazy?: boolean },
+    options?: { lazy?: boolean; cloneFrom?: TabId },
   ): Promise<TabId>;
   closeTab(tabId: TabId): Promise<void>;
   navigateTab(tabId: TabId, url: string): Promise<void>;


### PR DESCRIPTION
Add **Duplicate tab** to ordinary and pinned tab context menus and the `tabs:duplicate` command. Electron's cloned navigation controller preserves the active entry plus back/forward history; reloading that entry creates a fresh page without truncating forward history. The copy retains its session and initial zoom, then navigates and zooms independently.

Cloned contents pass through the normal tab lifecycle, permissions, navigation guards, shortcuts, events, and cleanup. Copies are ephemeral: normal tabs retain their workspace, global pins duplicate into the current workspace, and commands targeting an inactive workspace create background copies. Built-in/PDF tabs disable duplication; unloaded restored tabs copy their persisted URL.

Validation: full verification and app/design-system builds pass. Two native Windows scenarios cover same- and cross-origin history, forward history, cookie/session identity and isolation, fresh DOM state, initial and independent zoom, sub-tab lifecycle hooks, and closing either source or copy. Inspected the actual native menu screenshot; the scenario selects its native item callback because native menus have no CDP target.

Closes #43.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **Duplicate tab** action to tab and pinned-tab context menus.
  - Duplicated tabs preserve navigation history, session data, cookies, zoom settings, isolated mode, form state, and source customization.
  - Copies remain ephemeral, activate in the active workspace, and open in the background in inactive workspaces.
  - Duplication is unavailable for built-in, PDF, unsupported, missing, or unavailable tabs.

- **Documentation**
  - Documented duplicate-tab behavior, limitations, workspace placement, and customization.
  - Added specifications and end-to-end coverage for duplication scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->