### PR TITLE
Stabilize browser identity and add GitHub session diagnostics

### DIFF
--- a/docs/spec/implementation.md
+++ b/docs/spec/implementation.md
@@ -181,3 +181,16 @@ JSON files:       settings.json, shortcuts.json, extensions.json
 ```
 
 **Cloud sync (Convex — optional)**: All data is local-only by default. Convex can be added as a separate optional data store for selective cross-device sync (bookmarks, workspace definitions, user preferences). Convex is not a sync layer for RxDB — it's an independent store for data the user opts to sync. Local RxDB remains the source of truth; synced data is mirrored to/from Convex when connected.
+
+## Session identity and GitHub diagnostics
+
+Prepare each tab session's user-agent and permission handlers before constructing
+its web contents. Electron session user-agent changes do not update existing
+contents; doing this afterward gave the first tab a different identity. New tabs,
+sub-tabs and popup windows now inherit the same prepared identity. Normalize the
+app user-agent fallback too, since renderer-created popup contents use that value.
+
+A bounded, memory-only GitHub authentication timeline is available through the
+existing debug state provider. See [GitHub session diagnostics](../testing/github-session-diagnostics.md)
+for scope, redaction, and how to capture an overnight logout without exporting
+credentials. The confirmed identity fix does not close the unproven logout root cause.

--- a/docs/testing/github-session-diagnostics.md
+++ b/docs/testing/github-session-diagnostics.md
@@ -1,0 +1,57 @@
+# Investigating overnight GitHub logout
+
+The first-tab user-agent defect is fixed by preparing the session before constructing
+web contents, including Electron’s app fallback used by renderer-created popups.
+This does not establish why GitHub loses authentication overnight.
+A synthetic persistent-cookie restart test also cannot establish sleep/wake behavior.
+Keep issue #49 open until an actual logout transition is captured and explained.
+
+The app retains the latest 500 GitHub authentication observations in memory. Enable
+the existing debug server in Settings and inspect its configured local port (default
+19400):
+
+```sh
+curl 'http://127.0.0.1:19400/state/github-session?pretty' > github-session.json
+```
+
+Automation instances require their own bearer token. The existing Host/Origin and
+local access restrictions apply. The diagnostic buffer is discarded on process exit;
+export it after the failure and before restarting. No network traffic is generated
+by the diagnostics, and they do not change cookies, headers, or server responses.
+
+The timeline contains:
+
+- Session persistence and browser user-agent identity.
+- Presence/expiry metadata and change/removal reasons for `user_session`,
+  `__Host-user_session_same_site`, `logged_in`, `dotcom_user`, and `_gh_sess` cookies
+  scoped to `github.com`.
+- Which of those names appeared in the final outgoing Cookie header for top-level
+  GitHub requests, the sent and tab user agents, and the native request ID.
+- Redirect categories and response statuses correlated by request ID. Paths are
+  reduced to `sign-in`, `session`, `github-page`, or `external`.
+- Cookie snapshots at initialization, suspend, resume, and a sign-in redirect.
+  `startedAt` records when each asynchronous snapshot began; its entry timestamp is
+  completion time. A suspend snapshot may not finish until Windows resumes.
+
+Cookie values, authentication headers, request bodies, full paths/URLs, query
+parameters, and account/repository names are never retained. Only the User-Agent
+header and allowlisted cookie-name presence are recorded. Other cookies and
+subresource requests are ignored. Request observers own `onSendHeaders`,
+`onBeforeRedirect`, and `onCompleted` for the observed session; Electron supports one
+listener per event, so future network observers must compose with these handlers.
+
+To diagnose a failure, compare the last successful request with the request preceding
+a sign-in redirect:
+
+1. If cookies vanished, inspect `cookie-changed` removal causes and expiration times.
+2. If cookies exist but were not sent, investigate cookie scope, SameSite/secure
+   rules, and the request context.
+3. If cookies were sent but a sign-in redirect followed, investigate server-side
+   session invalidation and request differences. A redirect alone does not prove
+   user-agent rejection.
+
+Validation covers local first/subsequent tabs, sub-tabs, a simulated OAuth popup,
+actual outgoing user agents, real Electron cookie events, and persistent cookies
+across normal restart. Unit tests cover redaction, cookie removal, redirect
+correlation, and a simulated resume snapshot. Real GitHub authentication and an
+actual overnight Windows sleep/wake transition still require capture.

--- a/e2e/automation/site.ts
+++ b/e2e/automation/site.ts
@@ -26,8 +26,9 @@ export function samplePdf(): Buffer {
   return Buffer.from(pdf);
 }
 
-export async function startSite() {
+export async function startSite(onRequest?: (request: http.IncomingMessage) => void) {
   const server = http.createServer((request, response) => {
+    onRequest?.(request);
     const url = new URL(request.url ?? "/", "http://localhost");
     if (url.pathname === "/sample.pdf") {
       response.writeHead(200, { "Content-Type": "application/pdf" });

--- a/e2e/scenarios/session-identity.spec.ts
+++ b/e2e/scenarios/session-identity.spec.ts
@@ -68,6 +68,12 @@ test("first and subsequent tabs, sub-tabs and OAuth popups share a stable browse
     expect(await restarted.page.evaluate(() => document.cookie)).toContain(
       "persistent-identity-fixture=survives-restart",
     );
+    await expect
+      .poll(async () => {
+        const state = await session.debug<{ entries: { kind: string }[] }>("/state/github-session");
+        return state.entries.some((entry) => entry.kind === "cookie-snapshot");
+      })
+      .toBe(true);
     const diagnostics = await session.debug<{ entries: { kind: string; data: unknown }[] }>(
       "/state/github-session",
     );

--- a/e2e/scenarios/session-identity.spec.ts
+++ b/e2e/scenarios/session-identity.spec.ts
@@ -1,0 +1,92 @@
+import { startSite } from "../automation/site";
+import { expect, test } from "../fixtures/electron-app";
+import { VerificationPage } from "../pages/verification.page";
+
+test("first and subsequent tabs, sub-tabs and OAuth popups share a stable browser identity", async ({
+  appSession: session,
+}) => {
+  test.setTimeout(60_000);
+  const userAgents = new Map<string, string | undefined>();
+  const site = await startSite((request) =>
+    userAgents.set(request.url ?? "", request.headers["user-agent"]),
+  );
+  try {
+    const first = await VerificationPage.navigate(session, `${site.url}/identity-first`);
+    const expected = await first.page.evaluate(() => navigator.userAgent);
+    expect(expected).toContain("Chrome/");
+    expect(expected).not.toMatch(/Electron|chiaroscuro/i);
+    expect(userAgents.get("/identity-first")).toBe(expected);
+    const target = await session.target(
+      (t) => t.kind === "tab" && t.url.endsWith("/identity-first"),
+    );
+    await session.app.evaluate(
+      async ({ webContents }, { id, url }) => {
+        const ses = webContents.fromId(id)!.session;
+        await ses.cookies.set({
+          url,
+          name: "persistent-identity-fixture",
+          value: "survives-restart",
+          expirationDate: Date.now() / 1000 + 86400,
+        });
+        await ses.cookies.set({
+          url: "https://github.com",
+          name: "user_session",
+          value: "DO_NOT_LOG_AUTH_SENTINEL",
+          httpOnly: true,
+          secure: true,
+          expirationDate: Date.now() / 1000 + 86400,
+        });
+        await ses.cookies.flushStore();
+      },
+      { id: target.webContentsId, url: site.url },
+    );
+    const second = await VerificationPage.navigate(session, `${site.url}/identity-second`);
+    expect(await second.page.evaluate(() => navigator.userAgent)).toBe(expected);
+    expect(userAgents.get("/identity-second")).toBe(expected);
+    await second.subTab.click();
+    const childTarget = await session.target(
+      (t) => t.kind === "sub-tab" && t.url.endsWith("/child"),
+    );
+    const child = await session.page(childTarget);
+    expect(await child.evaluate(() => navigator.userAgent)).toBe(expected);
+    expect(userAgents.get("/child")).toBe(expected);
+    const frame = await session.page(await session.target((t) => t.kind === "sub-tab-frame"));
+    const cursor = await session.eventCursor();
+    await frame.getByRole("button", { name: "Close sub-tab" }).click();
+    await session.waitForEvent("sub-tabs:closed", cursor);
+    await second.popup.click();
+    const popup = await session.page(
+      await session.target((t) => t.kind === "window" && t.url.endsWith("/popup")),
+    );
+    expect(await popup.evaluate(() => navigator.userAgent)).toBe(expected);
+    expect(userAgents.get("/popup")).toBe(expected);
+    await popup.close();
+    await session.restart();
+    const restarted = await VerificationPage.navigate(session, `${site.url}/identity-restarted`);
+    expect(await restarted.page.evaluate(() => navigator.userAgent)).toBe(expected);
+    expect(userAgents.get("/identity-restarted")).toBe(expected);
+    expect(await restarted.page.evaluate(() => document.cookie)).toContain(
+      "persistent-identity-fixture=survives-restart",
+    );
+    const diagnostics = await session.debug<{ entries: { kind: string; data: unknown }[] }>(
+      "/state/github-session",
+    );
+    expect(diagnostics.entries).toContainEqual(
+      expect.objectContaining({
+        kind: "session-ready",
+        data: expect.objectContaining({ userAgent: expected, persistent: true }),
+      }),
+    );
+    expect(diagnostics.entries).toContainEqual(
+      expect.objectContaining({
+        kind: "cookie-snapshot",
+        data: expect.objectContaining({
+          cookies: [expect.objectContaining({ name: "user_session", httpOnly: true })],
+        }),
+      }),
+    );
+    expect(JSON.stringify(diagnostics)).not.toMatch(/survives-restart|DO_NOT_LOG_AUTH_SENTINEL/);
+  } finally {
+    await site.close();
+  }
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 import { mkdirSync } from "node:fs";
 import path from "node:path";
-import { app, BrowserWindow, ipcMain, Menu, screen } from "electron";
+import { app, BrowserWindow, ipcMain, Menu, powerMonitor, screen } from "electron";
 import { CommandBus } from "../bus/command-bus";
 import { EventBus } from "../bus/event-bus";
 import { bridgeBusToIpc } from "../bus/ipc-main-bridge";
@@ -122,6 +122,7 @@ import type {
 import zoom from "../features/zoom/zoom.main";
 import type { ZoomCommands, ZoomEvents } from "../features/zoom/zoom.shared";
 import { ElectronPlatform } from "../platform/electron";
+import { GithubSessionDiagnostics } from "../platform/github-session-diagnostics";
 import { logError } from "../shared/log";
 import type { TabId, WindowId, WorkspaceId } from "../shared/types";
 
@@ -242,7 +243,8 @@ let activeWorkspaceId: WorkspaceId | undefined;
 
 if (isDev && process.env.NODE_ENV !== "test")
   app.setPath("userData", path.join(app.getPath("userData"), "..", "chiaroscuro-dev"));
-const platform = new ElectronPlatform(() => activeWindowId);
+const githubSessions = new GithubSessionDiagnostics();
+const platform = new ElectronPlatform(() => activeWindowId, githubSessions);
 const dataDir = process.env.DATA_DIR ?? path.join(app.getPath("userData"), "data");
 const dataStore: DataStore = createDataStore(dataDir);
 
@@ -410,6 +412,7 @@ if (gotLock) {
       return { all, activeTabId };
     });
     registerDebugState("workspaces", () => ({ activeWorkspaceId }));
+    registerDebugState("github-session", () => githubSessions.getState());
     registerDebugState("settings", () => commands.send(SETTINGS_GET, undefined).catch(() => null));
     registerDebugState("window", () => {
       const win =
@@ -422,6 +425,8 @@ if (gotLock) {
         maximized: win && !win.isDestroyed() ? win.isMaximized() : null,
       };
     });
+    powerMonitor.on("suspend", () => void githubSessions.snapshot("suspend"));
+    powerMonitor.on("resume", () => void githubSessions.snapshot("resume"));
     registerDebugState("debug-server", () => ({ actualPort: getActualPort() }));
     registerDebugState("sub-tabs", getSubTabSnapshot);
     registerDebugState("targets", () => {

--- a/src/platform/electron.ts
+++ b/src/platform/electron.ts
@@ -16,6 +16,7 @@ import {
   webContents,
 } from "electron";
 import type { Bounds, TabId, WindowId } from "../shared/types";
+import type { GithubSessionDiagnostics } from "./github-session-diagnostics";
 import type { Platform, PlatformDownload } from "./types";
 
 const ALLOWED_SCHEMES_WEB = new Set(["http:", "https:", "about:", "data:"]);
@@ -368,7 +369,10 @@ export class ElectronPlatform implements Platform {
       ) => boolean)
     | undefined;
 
-  constructor(private getActiveWindowId: () => WindowId | undefined) {}
+  constructor(
+    private getActiveWindowId: () => WindowId | undefined,
+    private readonly sessionDiagnostics?: GithubSessionDiagnostics,
+  ) {}
 
   private getWin(windowId?: WindowId): BrowserWindow | undefined {
     const id = windowId ?? this.getActiveWindowId();
@@ -434,9 +438,13 @@ export class ElectronPlatform implements Platform {
     const win = this.getWin(windowId);
     if (!win) throw new Error("No window found");
 
+    // Session UA changes do not update existing web contents. Prepare it before construction.
+    const tabSession = session.defaultSession;
+    this.prepareSession(tabSession);
     const tabId = existingTabId ?? (crypto.randomUUID() as TabId);
     const view = new WebContentsView({
       webPreferences: {
+        session: tabSession,
         sandbox: true,
         contextIsolation: true,
         nodeIntegration: false,
@@ -457,13 +465,6 @@ export class ElectronPlatform implements Platform {
 
     // Hide initially — caller will activate
     view.setBounds({ x: 0, y: 0, width: 0, height: 0 });
-
-    const ses = view.webContents.session;
-    if (!this.sessionsWithHandlers.has(ses)) {
-      this.installPermissionHandlers(ses);
-      this.installDevicePermissionHandlers(ses);
-      this.sessionsWithHandlers.add(ses);
-    }
 
     view.webContents.setWindowOpenHandler(({ url, disposition }) => {
       // Check per-tab navigation blocking for new tabs/windows
@@ -1585,12 +1586,21 @@ export class ElectronPlatform implements Platform {
     return undefined;
   }
 
-  private installPermissionHandlers(ses: Electron.Session): void {
-    // Present as standard Chrome so sites like Google don't block OAuth
-    // flows due to detecting "Electron" in the user-agent string.
-    const ua = ses.getUserAgent();
-    ses.setUserAgent(ua.replace(/ Electron\/\S+/g, "").replace(/ \S+\/\S+(?= Chrome\/)/g, ""));
+  private prepareSession(ses: Electron.Session): void {
+    if (this.sessionsWithHandlers.has(ses)) return;
+    // Present a consistent standard Chrome identity from the very first tab onward.
+    const chromeIdentity = (ua: string) =>
+      ua.replace(/ Electron\/\S+/g, "").replace(/ \S+\/\S+(?= Chrome\/)/g, "");
+    // Renderer-created window.open contents use the app fallback instead of the session UA.
+    app.userAgentFallback = chromeIdentity(app.userAgentFallback);
+    ses.setUserAgent(chromeIdentity(ses.getUserAgent()));
+    this.installPermissionHandlers(ses);
+    this.installDevicePermissionHandlers(ses);
+    this.sessionsWithHandlers.add(ses);
+    this.sessionDiagnostics?.observe(ses);
+  }
 
+  private installPermissionHandlers(ses: Electron.Session): void {
     ses.setPermissionRequestHandler((wc, permission, callback, details) => {
       if (!this.permissionRequestHandler) {
         callback(false);

--- a/src/platform/github-session-diagnostics.test.ts
+++ b/src/platform/github-session-diagnostics.test.ts
@@ -1,0 +1,123 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { GithubSessionDiagnostics } from "./github-session-diagnostics";
+
+function fixture() {
+  const cookies = Object.assign(new EventEmitter(), {
+    get: vi.fn(async () => [
+      {
+        name: "user_session",
+        value: "SECRET_COOKIE",
+        domain: ".github.com",
+        path: "/",
+        secure: true,
+        httpOnly: true,
+        session: false,
+        expirationDate: 1900000000,
+      },
+      { name: "unrelated", value: "SECRET_UNRELATED", domain: ".github.com" },
+    ]),
+  });
+  const webRequest = { onSendHeaders: vi.fn(), onBeforeRedirect: vi.fn(), onCompleted: vi.fn() };
+  const ses = {
+    cookies,
+    webRequest,
+    getUserAgent: () => "Chrome/test",
+    isPersistent: () => true,
+  } as unknown as Electron.Session;
+  const diagnostics = new GithubSessionDiagnostics();
+  diagnostics.observe(ses);
+  return { diagnostics, ses, cookies, webRequest };
+}
+
+describe("GitHub authentication diagnostics", () => {
+  it("keeps metadata, correlates sent cookies and login redirects, and never retains secrets", async () => {
+    const { diagnostics, ses, cookies, webRequest } = fixture();
+    diagnostics.observe(ses);
+    expect(webRequest.onSendHeaders).toHaveBeenCalledOnce();
+    const request = webRequest.onSendHeaders.mock.calls[0]![1];
+    const redirect = webRequest.onBeforeRedirect.mock.calls[0]![1];
+    request({
+      id: 1,
+      url: "https://github.com/private-repo?token=SECRET_QUERY",
+      resourceType: "mainFrame",
+      webContentsId: 5,
+      requestHeaders: {
+        Cookie: "user_session=SECRET_COOKIE; unrelated=SECRET_UNRELATED",
+        Authorization: "Bearer SECRET_AUTH",
+        "User-Agent": "Chrome/test",
+      },
+    });
+    redirect({
+      id: 1,
+      url: "https://github.com/private-repo",
+      redirectURL: "https://github.com/login?return_to=SECRET_RETURN",
+      resourceType: "mainFrame",
+      statusCode: 302,
+    });
+    cookies.emit(
+      "changed",
+      {},
+      { name: "user_session", value: "SECRET_REMOVAL", domain: ".github.com", path: "/" },
+      "expired",
+      true,
+    );
+    await diagnostics.snapshot("resume");
+    const state = diagnostics.getState();
+    expect(state.entries).toContainEqual(
+      expect.objectContaining({
+        kind: "request",
+        data: expect.objectContaining({
+          requestId: 1,
+          sentCookies: expect.objectContaining({ user_session: true, logged_in: false }),
+        }),
+      }),
+    );
+    expect(state.entries).toContainEqual(
+      expect.objectContaining({
+        kind: "redirect",
+        data: { requestId: 1, status: 302, from: "github-page", to: "sign-in" },
+      }),
+    );
+    expect(state.entries).toContainEqual(
+      expect.objectContaining({
+        kind: "cookie-changed",
+        data: expect.objectContaining({ cause: "expired", removed: true }),
+      }),
+    );
+    expect(state.entries).toContainEqual(
+      expect.objectContaining({
+        kind: "cookie-snapshot",
+        data: expect.objectContaining({
+          reason: "resume",
+          cookies: [expect.objectContaining({ name: "user_session", expiresAt: 1900000000 })],
+        }),
+      }),
+    );
+    expect(JSON.stringify(state)).not.toMatch(/SECRET|private-repo|Authorization|unrelated/);
+  });
+
+  it("ignores other domains and subresources and bounds retained history", () => {
+    const { diagnostics, cookies, webRequest } = fixture();
+    const request = webRequest.onSendHeaders.mock.calls[0]![1];
+    const before = diagnostics.getState().entries.length;
+    cookies.emit(
+      "changed",
+      {},
+      { name: "user_session", domain: "notgithub.com", value: "SECRET" },
+      "explicit",
+      true,
+    );
+    request({ id: 1, url: "https://github.com/api", resourceType: "xhr", requestHeaders: {} });
+    request({
+      id: 2,
+      url: "https://github.com.evil.test/login",
+      resourceType: "mainFrame",
+      requestHeaders: {},
+    });
+    expect(diagnostics.getState().entries).toHaveLength(before);
+    for (let i = 0; i < 600; i++)
+      request({ id: i, url: "https://github.com/", resourceType: "mainFrame", requestHeaders: {} });
+    expect(diagnostics.getState().entries).toHaveLength(500);
+  });
+});

--- a/src/platform/github-session-diagnostics.ts
+++ b/src/platform/github-session-diagnostics.ts
@@ -1,0 +1,145 @@
+import type { Cookie, Session } from "electron";
+
+const COOKIE_NAMES = [
+  "user_session",
+  "__Host-user_session_same_site",
+  "logged_in",
+  "dotcom_user",
+  "_gh_sess",
+] as const;
+const AUTH_COOKIES = new Set<string>(COOKIE_NAMES);
+const LIMIT = 500;
+const FILTER = { urls: ["https://github.com/*"] };
+
+type Entry = { timestamp: number; session: number; kind: string; data: unknown };
+
+/** Categorize routes without retaining account/repository paths, queries, or redirect tokens. */
+function route(url: string): "sign-in" | "session" | "github-page" | "external" {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname !== "github.com" || parsed.protocol !== "https:") return "external";
+    if (parsed.pathname === "/login" || parsed.pathname.startsWith("/login/")) return "sign-in";
+    if (parsed.pathname === "/session" || parsed.pathname.startsWith("/sessions/"))
+      return "session";
+    return "github-page";
+  } catch {
+    return "external";
+  }
+}
+
+function cookieMetadata(cookie: Cookie) {
+  return {
+    name: cookie.name,
+    secure: cookie.secure,
+    httpOnly: cookie.httpOnly,
+    sameSite: cookie.sameSite,
+    sessionCookie: cookie.session,
+    expiresAt: cookie.expirationDate ?? null,
+    rootPath: cookie.path === "/",
+  };
+}
+
+function isAuthCookie(cookie: Cookie): boolean {
+  return AUTH_COOKIES.has(cookie.name) && cookie.domain?.replace(/^\./, "") === "github.com";
+}
+
+function header(headers: Record<string, string>, name: string): string | undefined {
+  return Object.entries(headers).find(([key]) => key.toLowerCase() === name)?.[1];
+}
+
+function cookiePresence(headers: Record<string, string>) {
+  const names = new Set(
+    (header(headers, "cookie") ?? "")
+      .split(";")
+      .map((part) => part.slice(0, part.indexOf("=")).trim()),
+  );
+  return Object.fromEntries(COOKIE_NAMES.map((name) => [name, names.has(name)]));
+}
+
+/** Passive, in-memory evidence for #49. Never retain cookie values, authentication headers, URLs, or page content. */
+export class GithubSessionDiagnostics {
+  private readonly sessions = new Map<Session, number>();
+  private readonly entries: Entry[] = [];
+
+  private record(session: number, kind: string, data: unknown) {
+    this.entries.push({ timestamp: Date.now(), session, kind, data });
+    if (this.entries.length > LIMIT) this.entries.shift();
+  }
+
+  observe(ses: Session): void {
+    if (this.sessions.has(ses)) return;
+    const id = this.sessions.size + 1;
+    this.sessions.set(ses, id);
+    this.record(id, "session-ready", {
+      persistent: ses.isPersistent(),
+      userAgent: ses.getUserAgent(),
+    });
+    ses.cookies.on("changed", (_event, cookie, cause, removed) => {
+      if (isAuthCookie(cookie))
+        this.record(id, "cookie-changed", { ...cookieMetadata(cookie), cause, removed });
+    });
+    // Electron allows one observer per webRequest event. These hooks currently have no
+    // other owner; future consumers must compose with them instead of replacing them.
+    ses.webRequest.onSendHeaders(FILTER, (details) => {
+      if (details.resourceType !== "mainFrame" || route(details.url) === "external") return;
+      const contents = details.webContents;
+      this.record(id, "request", {
+        requestId: details.id,
+        webContentsId: details.webContentsId ?? null,
+        route: route(details.url),
+        sentCookies: cookiePresence(details.requestHeaders),
+        userAgent: header(details.requestHeaders, "user-agent")?.slice(0, 512) ?? null,
+        tabUserAgent:
+          contents && !contents.isDestroyed() ? contents.getUserAgent().slice(0, 512) : null,
+      });
+    });
+    ses.webRequest.onBeforeRedirect(FILTER, (details) => {
+      if (details.resourceType !== "mainFrame" || route(details.url) === "external") return;
+      const destination = route(details.redirectURL);
+      this.record(id, "redirect", {
+        requestId: details.id,
+        status: details.statusCode,
+        from: route(details.url),
+        to: destination,
+      });
+      if (destination === "sign-in") void this.snapshotSession(ses, id, "sign-in-redirect");
+    });
+    ses.webRequest.onCompleted(FILTER, (details) => {
+      if (details.resourceType !== "mainFrame" || route(details.url) === "external") return;
+      this.record(id, "response", {
+        requestId: details.id,
+        status: details.statusCode,
+        route: route(details.url),
+      });
+    });
+    void this.snapshotSession(ses, id, "session-ready");
+  }
+
+  private async snapshotSession(ses: Session, id: number, reason: string): Promise<void> {
+    const startedAt = Date.now();
+    try {
+      const cookies = await ses.cookies.get({ domain: "github.com" });
+      this.record(id, "cookie-snapshot", {
+        reason,
+        startedAt,
+        cookies: cookies.filter(isAuthCookie).map(cookieMetadata),
+      });
+    } catch {
+      // Error text can include paths or request data; retain only the failed operation.
+      this.record(id, "snapshot-unavailable", { reason });
+    }
+  }
+
+  async snapshot(reason: "suspend" | "resume"): Promise<void> {
+    for (const id of this.sessions.values()) this.record(id, reason, {});
+    await Promise.all([...this.sessions].map(([ses, id]) => this.snapshotSession(ses, id, reason)));
+  }
+
+  getState() {
+    return {
+      scope: "GitHub authentication metadata only",
+      maxEntries: LIMIT,
+      entries: this.entries.slice(),
+    };
+  }
+}


### PR DESCRIPTION
Prepare session identity before creating the first tab, and normalize Electron's app user-agent fallback used by renderer-created OAuth popups. Previously the first tab and popup windows could identify as Electron while later tabs identified as Chrome.

Add a bounded, memory-only GitHub authentication diagnostic timeline through the existing debug state endpoint. It records allowlisted cookie-name presence/expiry/removal reasons, the final outgoing cookie-name presence, user agents, request/redirect correlation, and suspend/resume snapshots. It excludes cookie values, authentication headers, URL paths/queries, and account/repository names. Diagnostics do not change requests, cookies, or responses.

Validation: full verification and all 56 Linux E2E tests pass. Native Windows tests compare actual outgoing user agents for first/subsequent tabs, duplicated tabs, sub-tabs, and a local OAuth-style popup; verify persistent cookies and identity across normal restart; and check real Electron cookie events without exposing a sentinel value. Unit tests cover redaction, removal causes, redirect correlation, simulated resume, and bounded retention.

Refs #49. The identity defects are confirmed and fixed; their relationship to overnight logout is unproven. Real GitHub authentication and an overnight Windows sleep/wake transition still require capture, so this PR deliberately leaves #49 open. The user is unsure whether logout requires sleep, so both awake and sleep/resume paths remain under investigation. The capture guide explains how to distinguish missing cookies, omitted cookies, and server rejection.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to duplicate tabs while preserving their session and browsing context.
  - Improved consistent browser identity across tabs, sub-tabs, popups, and app restarts.
  - Added bounded, privacy-conscious diagnostics for investigating GitHub sign-in and session issues.
  - Added automatic session snapshots when the system suspends or resumes.

- **Documentation**
  - Documented session identity behavior and GitHub diagnostic workflows, including data retention and redaction guidance.

- **Tests**
  - Added coverage for tab identity, session persistence, diagnostics, filtering, and sensitive-data protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->